### PR TITLE
chore: add CPM, Directory.Build.props, and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,47 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.{csproj,props,targets,xml}]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+indent_style = tab
+tab_width = 4
+
+# Align with existing conventions
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_sort_system_directives_first = true
+csharp_using_directive_placement = outside_namespace:warning
+
+# var usage (matches rule: use var when type is obvious)
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_for_builtins = false:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Braces
+csharp_prefer_braces = true:warning
+
+# Expression-bodied members (DbSet convention uses these)
+csharp_style_expression_bodied_properties = true:suggestion
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# EF Core scaffolded migration files — suppress style rules
+[api/src/Migrations/**.cs]
+generated_code = true
+dotnet_analyzer_diagnostic.severity = none
+
+# Test files — underscore naming is intentional (three-part pattern convention)
+[api/tests/**.cs]
+dotnet_diagnostic.CA1707.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+</Project>

--- a/api/src/DailyWork.Api.csproj
+++ b/api/src/DailyWork.Api.csproj
@@ -1,18 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
 </Project>

--- a/api/src/Endpoints/ReadWatchEndpoints.cs
+++ b/api/src/Endpoints/ReadWatchEndpoints.cs
@@ -7,60 +7,77 @@ namespace DailyWork.Api.Endpoints;
 
 internal static class ReadWatchEndpoints
 {
-    public static RouteGroupBuilder MapReadWatchEndpoints(this WebApplication app)
-    {
-        var group = app.MapGroup("/api/read-watch");
+	public static RouteGroupBuilder MapReadWatchEndpoints(this WebApplication app)
+	{
+		var group = app.MapGroup("/api/read-watch");
 
-        group.MapGet("/", async (AppDbContext db, DateTime? date) =>
-        {
-            var d = (date ?? DateTime.Today).Date;
-            return await db.ReadWatchItems
-                .Where(r => r.Date == d)
-                .OrderBy(r => r.CreatedAt)
-                .ToListAsync();
-        });
+		group.MapGet("/", async (AppDbContext db, DateTime? date) =>
+		{
+			var d = (date ?? DateTime.Today).Date;
+			return await db.ReadWatchItems
+				.Where(r => r.Date == d)
+				.OrderBy(r => r.CreatedAt)
+				.ToListAsync();
+		});
 
-        group.MapPost("/", async (AppDbContext db, CreateReadWatchItemDto dto) =>
-        {
-            var d = (dto.Date ?? DateTime.Today).Date;
-            var count = await db.ReadWatchItems.CountAsync(r => r.Date == d);
-            if (count >= 5)
-                return Results.Problem("Maximum of 5 read/watch items per day.", statusCode: 400);
+		group.MapPost("/", async (AppDbContext db, CreateReadWatchItemDto dto) =>
+		{
+			var d = (dto.Date ?? DateTime.Today).Date;
+			var count = await db.ReadWatchItems.CountAsync(r => r.Date == d);
+			if (count >= 5)
+			{
+				return Results.Problem("Maximum of 5 read/watch items per day.", statusCode: 400);
+			}
 
-            var item = new ReadWatchItem
-            {
-                Title = dto.Title,
-                Url = dto.Url,
-                Date = d
-            };
-            db.ReadWatchItems.Add(item);
-            await db.SaveChangesAsync();
-            return Results.Created($"/api/read-watch/{item.Id}", item);
-        });
+			var item = new ReadWatchItem
+			{
+				Title = dto.Title,
+				Url = dto.Url,
+				Date = d
+			};
+			db.ReadWatchItems.Add(item);
+			await db.SaveChangesAsync();
+			return Results.Created($"/api/read-watch/{item.Id}", item);
+		});
 
-        group.MapPut("/{id}", async (AppDbContext db, int id, UpdateReadWatchItemDto dto) =>
-        {
-            var item = await db.ReadWatchItems.FindAsync(id);
-            if (item is null) return Results.NotFound();
+		group.MapPut("/{id}", async (AppDbContext db, int id, UpdateReadWatchItemDto dto) =>
+		{
+			var item = await db.ReadWatchItems.FindAsync(id);
+			if (item is null)
+			{
+				return Results.NotFound();
+			}
 
-            if (dto.Title is not null) item.Title = dto.Title;
-            if (dto.Url is not null) item.Url = dto.Url;
-            if (dto.IsDone.HasValue) item.IsDone = dto.IsDone.Value;
+			if (dto.Title is not null)
+			{
+				item.Title = dto.Title;
+			}
+			if (dto.Url is not null)
+			{
+				item.Url = dto.Url;
+			}
+			if (dto.IsDone.HasValue)
+			{
+				item.IsDone = dto.IsDone.Value;
+			}
 
-            await db.SaveChangesAsync();
-            return Results.Ok(item);
-        });
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
+		});
 
-        group.MapDelete("/{id}", async (AppDbContext db, int id) =>
-        {
-            var item = await db.ReadWatchItems.FindAsync(id);
-            if (item is null) return Results.NotFound();
+		group.MapDelete("/{id}", async (AppDbContext db, int id) =>
+		{
+			var item = await db.ReadWatchItems.FindAsync(id);
+			if (item is null)
+			{
+				return Results.NotFound();
+			}
 
-            db.ReadWatchItems.Remove(item);
-            await db.SaveChangesAsync();
-            return Results.NoContent();
-        });
+			db.ReadWatchItems.Remove(item);
+			await db.SaveChangesAsync();
+			return Results.NoContent();
+		});
 
-        return group;
-    }
+		return group;
+	}
 }

--- a/api/src/Endpoints/WorkItemEndpoints.cs
+++ b/api/src/Endpoints/WorkItemEndpoints.cs
@@ -8,84 +8,104 @@ namespace DailyWork.Api.Endpoints;
 
 internal static class WorkItemEndpoints
 {
-    public static RouteGroupBuilder MapWorkItemEndpoints(this WebApplication app)
-    {
-        var group = app.MapGroup("/api/work-items");
+	public static RouteGroupBuilder MapWorkItemEndpoints(this WebApplication app)
+	{
+		var group = app.MapGroup("/api/work-items");
 
-        group.MapGet("/", async (AppDbContext db, DateTime? date) =>
-        {
-            var d = (date ?? DateTime.Today).Date;
-            return await db.WorkItems
-                .Where(w => w.Date == d)
-                .OrderBy(w => w.CreatedAt)
-                .ToListAsync();
-        });
+		group.MapGet("/", async (AppDbContext db, DateTime? date) =>
+		{
+			var d = (date ?? DateTime.Today).Date;
+			return await db.WorkItems
+				.Where(w => w.Date == d)
+				.OrderBy(w => w.CreatedAt)
+				.ToListAsync();
+		});
 
-        group.MapPost("/", async (AppDbContext db, CreateWorkItemDto dto) =>
-        {
-            var item = new WorkItem
-            {
-                Title = dto.Title,
-                Category = Enum.TryParse<WorkItemCategory>(dto.Category, out var cat)
-                    ? cat
-                    : WorkItemCategory.SmallThing,
-                Date = (dto.Date ?? DateTime.Today).Date
-            };
-            db.WorkItems.Add(item);
-            await db.SaveChangesAsync();
-            return Results.Created($"/api/work-items/{item.Id}", item);
-        });
+		group.MapPost("/", async (AppDbContext db, CreateWorkItemDto dto) =>
+		{
+			var item = new WorkItem
+			{
+				Title = dto.Title,
+				Category = Enum.TryParse<WorkItemCategory>(dto.Category, out var cat)
+					? cat
+					: WorkItemCategory.SmallThing,
+				Date = (dto.Date ?? DateTime.Today).Date
+			};
+			db.WorkItems.Add(item);
+			await db.SaveChangesAsync();
+			return Results.Created($"/api/work-items/{item.Id}", item);
+		});
 
-        group.MapPut("/{id}", async (AppDbContext db, int id, UpdateWorkItemDto dto) =>
-        {
-            var item = await db.WorkItems.FindAsync(id);
-            if (item is null) return Results.NotFound();
+		group.MapPut("/{id}", async (AppDbContext db, int id, UpdateWorkItemDto dto) =>
+		{
+			var item = await db.WorkItems.FindAsync(id);
+			if (item is null)
+			{
+				return Results.NotFound();
+			}
 
-            if (dto.Title is not null) item.Title = dto.Title;
-            if (dto.IsDone.HasValue) item.IsDone = dto.IsDone.Value;
+			if (dto.Title is not null)
+			{
+				item.Title = dto.Title;
+			}
+			if (dto.IsDone.HasValue)
+			{
+				item.IsDone = dto.IsDone.Value;
+			}
 
-            await db.SaveChangesAsync();
-            return Results.Ok(item);
-        });
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
+		});
 
-        group.MapPut("/{id}/promote", async (AppDbContext db, int id) =>
-        {
-            var item = await db.WorkItems.FindAsync(id);
-            if (item is null) return Results.NotFound();
+		group.MapPut("/{id}/promote", async (AppDbContext db, int id) =>
+		{
+			var item = await db.WorkItems.FindAsync(id);
+			if (item is null)
+			{
+				return Results.NotFound();
+			}
 
-            // Demote any existing BigThing for the same date
-            var existing = await db.WorkItems
-                .Where(w => w.Date == item.Date && w.Category == WorkItemCategory.BigThing && w.Id != id)
-                .ToListAsync();
+			// Demote any existing BigThing for the same date
+			var existing = await db.WorkItems
+				.Where(w => w.Date == item.Date && w.Category == WorkItemCategory.BigThing && w.Id != id)
+				.ToListAsync();
 
-            foreach (var e in existing)
-                e.Category = WorkItemCategory.SmallThing;
+			foreach (var e in existing)
+			{
+				e.Category = WorkItemCategory.SmallThing;
+			}
 
-            item.Category = WorkItemCategory.BigThing;
-            await db.SaveChangesAsync();
-            return Results.Ok(item);
-        });
+			item.Category = WorkItemCategory.BigThing;
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
+		});
 
-        group.MapPut("/{id}/demote", async (AppDbContext db, int id) =>
-        {
-            var item = await db.WorkItems.FindAsync(id);
-            if (item is null) return Results.NotFound();
+		group.MapPut("/{id}/demote", async (AppDbContext db, int id) =>
+		{
+			var item = await db.WorkItems.FindAsync(id);
+			if (item is null)
+			{
+				return Results.NotFound();
+			}
 
-            item.Category = WorkItemCategory.SmallThing;
-            await db.SaveChangesAsync();
-            return Results.Ok(item);
-        });
+			item.Category = WorkItemCategory.SmallThing;
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
+		});
 
-        group.MapDelete("/{id}", async (AppDbContext db, int id) =>
-        {
-            var item = await db.WorkItems.FindAsync(id);
-            if (item is null) return Results.NotFound();
+		group.MapDelete("/{id}", async (AppDbContext db, int id) =>
+		{
+			var item = await db.WorkItems.FindAsync(id);
+			if (item is null)
+			{
+				return Results.NotFound();
+			}
 
-            db.WorkItems.Remove(item);
-            await db.SaveChangesAsync();
-            return Results.NoContent();
-        });
+			db.WorkItems.Remove(item);
+			await db.SaveChangesAsync();
+			return Results.NoContent();
+		});
 
-        return group;
-    }
+		return group;
+	}
 }

--- a/api/tests/DailyWork.Api.Tests.csproj
+++ b/api/tests/DailyWork.Api.Tests.csproj
@@ -1,20 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/api/tests/Fixtures/CustomWebApplicationFactory.cs
+++ b/api/tests/Fixtures/CustomWebApplicationFactory.cs
@@ -19,7 +19,9 @@ public class CustomWebApplicationFactory : WebApplicationFactory<IApiMarker>
             var descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
             if (descriptor != null)
+            {
                 services.Remove(descriptor);
+            }
 
             // Create and open a shared in-memory SQLite connection
             _connection = new SqliteConnection("DataSource=:memory:;Mode=Memory;Cache=Shared");


### PR DESCRIPTION
## Summary

- **Central Package Management** — `Directory.Packages.props` at repo root; all 8 package versions managed in one place, `Version` attributes removed from individual `PackageReference` elements
- **Shared build props** — `Directory.Build.props` hoists `TargetFramework`, `Nullable`, `ImplicitUsings`, `LangVersion` and adds `TreatWarningsAsErrors`, `AnalysisLevel=latest-recommended`, `EnforceCodeStyleInBuild`
- **`.editorconfig`** — tabs/CRLF, file-scoped namespaces, required braces, `var` conventions; suppressions for generated migrations (all diagnostics) and test method underscore names (CA1707)
- Endpoint and factory files updated with explicit braces to satisfy IDE0011 surfaced by the new enforcement

## Test plan

- [x] `dotnet build api/src` — clean, 0 warnings, 0 errors
- [x] `dotnet test api/tests` — 3/3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)