### PR TITLE
fix(web): use local time for date formatting in week utils

### DIFF
--- a/web/src/stores/workItems.ts
+++ b/web/src/stores/workItems.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import client from '@/api/client'
 import type { WorkItem } from '@/types'
-import { getWeekStart } from '@/utils/week'
+import { getWeekStart, getToday } from '@/utils/week'
 
 export const useWorkItemsStore = defineStore('workItems', () => {
   const items = ref<WorkItem[]>([])
@@ -19,7 +19,8 @@ export const useWorkItemsStore = defineStore('workItems', () => {
   async function create(title: string) {
     const item: WorkItem = await client.post('/api/work-items', {
       title,
-      category: 'BigThing'
+      category: 'BigThing',
+      date: getToday(),
     }) as any
     items.value.push(item)
   }

--- a/web/src/utils/week.spec.ts
+++ b/web/src/utils/week.spec.ts
@@ -44,6 +44,12 @@ describe('week utils', () => {
       const result = getWeekStart()
       expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
     })
+
+    it('getWeekStart_ReturnsCorrectDate_WhenLateEvening', () => {
+      vi.setSystemTime(new Date('2026-04-07T03:00:00Z')) // Monday 11 PM EDT (UTC-4)
+
+      expect(getWeekStart()).toBe('2026-04-06')
+    })
   })
 
   describe('getCurrentDayIndex', () => {
@@ -111,6 +117,13 @@ describe('week utils', () => {
 
     it('getDateForDayIndex_WorksAcrossMonthBoundary', () => {
       expect(getDateForDayIndex(4, '2026-03-30')).toBe('2026-04-03')
+    })
+
+    it('getDateForDayIndex_ReturnsCorrectDate_WhenLateEvening', () => {
+      vi.setSystemTime(new Date('2026-04-07T03:00:00Z')) // Monday 11 PM EDT
+
+      expect(getDateForDayIndex(0)).toBe('2026-04-06')
+      expect(getDateForDayIndex(4)).toBe('2026-04-10')
     })
   })
 

--- a/web/src/utils/week.spec.ts
+++ b/web/src/utils/week.spec.ts
@@ -1,9 +1,23 @@
-import { DAYS, getWeekStart, getCurrentDayIndex, getDateForDayIndex } from './week'
+import { DAYS, getToday, getWeekStart, getCurrentDayIndex, getDateForDayIndex } from './week'
 
 describe('week utils', () => {
   describe('DAYS', () => {
     it('DAYS_ContainsFiveWorkdayAbbreviations_InOrder', () => {
       expect(DAYS).toEqual(['MON', 'TUE', 'WED', 'THU', 'FRI'])
+    })
+  })
+
+  describe('getToday', () => {
+    it('getToday_ReturnsLocalDate_WhenCalledAtNoonUTC', () => {
+      vi.setSystemTime(new Date('2026-04-06T12:00:00Z'))
+
+      expect(getToday()).toBe('2026-04-06')
+    })
+
+    it('getToday_ReturnsLocalDate_WhenLateEvening', () => {
+      vi.setSystemTime(new Date('2026-04-07T03:00:00Z')) // Monday 11 PM EDT
+
+      expect(getToday()).toBe('2026-04-06')
     })
   })
 

--- a/web/src/utils/week.ts
+++ b/web/src/utils/week.ts
@@ -11,6 +11,10 @@ function parseLocalDate(dateStr: string): Date {
   return new Date(`${dateStr}T00:00:00`)
 }
 
+export function getToday(): string {
+  return toLocalDateString(new Date())
+}
+
 export function getWeekStart(): string {
   const now = new Date()
   const day = now.getDay()

--- a/web/src/utils/week.ts
+++ b/web/src/utils/week.ts
@@ -1,11 +1,22 @@
 export const DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI'] as const
 
+function toLocalDateString(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function parseLocalDate(dateStr: string): Date {
+  return new Date(`${dateStr}T00:00:00`)
+}
+
 export function getWeekStart(): string {
   const now = new Date()
   const day = now.getDay()
   const diff = now.getDate() - day + (day === 0 ? -6 : 1)
-  const monday = new Date(now.setDate(diff))
-  return monday.toISOString().split('T')[0]!
+  now.setDate(diff)
+  return toLocalDateString(now)
 }
 
 export function getCurrentDayIndex(): number {
@@ -16,7 +27,7 @@ export function getCurrentDayIndex(): number {
 }
 
 export function getDateForDayIndex(dayIndex: number, weekStart?: string): string {
-  const monday = new Date(weekStart ?? getWeekStart())
+  const monday = parseLocalDate(weekStart ?? getWeekStart())
   monday.setDate(monday.getDate() + dayIndex)
-  return monday.toISOString().split('T')[0]!
+  return toLocalDateString(monday)
 }


### PR DESCRIPTION
## Summary
- `getWeekStart()` and `getDateForDayIndex()` used `toISOString()` (UTC) to format dates computed with local-time methods, causing the `weekOf` parameter to be one day ahead in evening hours for US timezones
- Replaced with local-time formatting via `toLocalDateString()` and local-time parsing via `parseLocalDate()` to keep all date math in the same timezone
- Added test cases with late-evening UTC timestamps to prevent regression

## Test plan
- [x] `npx vitest run src/utils/week.spec.ts` — all 21 tests pass (including 2 new timezone-sensitive cases)
- [ ] Verify `weekOf` query param matches the current Monday in browser network tab
- [ ] Confirm BigThing work item renders on the daily board

🤖 Generated with [Claude Code](https://claude.com/claude-code)