### PR TITLE
chore(aspire): group docker containers under jb_daily-work project

### DIFF
--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using DailyWork.Api.Data;
 using DailyWork.Api.Dtos;
 using DailyWork.Api.Entities;
-using DailyWork.Api.Enums;
 using DailyWork.Api.Prompts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using DailyWork.Api.Data;
 using DailyWork.Api.Dtos;
 using DailyWork.Api.Entities;
+using DailyWork.Api.Enums;
 using DailyWork.Api.Prompts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel.ChatCompletion;

--- a/aspire/DailyWork.AppHost/Program.cs
+++ b/aspire/DailyWork.AppHost/Program.cs
@@ -1,9 +1,13 @@
+const string dockerProject = "jb_daily-work";
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
     .WithDataVolume("dailywork-postgres-data")
     .WithLifetime(ContainerLifetime.Persistent)
-    .WithPgAdmin();
+    .WithContainerRuntimeArgs("--label", $"com.docker.compose.project={dockerProject}")
+    .WithPgAdmin(pgAdmin => pgAdmin
+        .WithContainerRuntimeArgs("--label", $"com.docker.compose.project={dockerProject}"));
 
 var db = postgres.AddDatabase("dailywork");
 


### PR DESCRIPTION
## Summary
- Adds `com.docker.compose.project=jb_daily-work` label to the postgres and pgAdmin containers via `WithContainerRuntimeArgs`
- Both containers will now appear grouped together under **jb_daily-work** in Docker Desktop

## Test plan
- [ ] Run the Aspire app host
- [ ] Open Docker Desktop and confirm postgres and pgAdmin are grouped under `jb_daily-work`

🤖 Generated with [Claude Code](https://claude.com/claude-code)