### PR TITLE
fix: ScratchPad endpoints — SingleOrDefaultAsync, correct isActive on empty GET, safe clean()

### DIFF
--- a/api/src/Data/AppDbContext.cs
+++ b/api/src/Data/AppDbContext.cs
@@ -9,6 +9,7 @@ internal class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(
     public DbSet<WorkItem> WorkItems => Set<WorkItem>();
     public DbSet<ReadWatchItem> ReadWatchItems => Set<ReadWatchItem>();
     public DbSet<UpdateComm> UpdateComms => Set<UpdateComm>();
+    public DbSet<ScratchPad> ScratchPads => Set<ScratchPad>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -30,6 +31,11 @@ internal class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(
              .HasValue<DailyStandupComm>(CommType.DailyStandup)
              .HasValue<WeeklyUpdateComm>(CommType.WeeklyUpdate);
             e.HasIndex(c => new { c.Date, c.CommType }).IsUnique();
+        });
+
+        modelBuilder.Entity<ScratchPad>(e =>
+        {
+            e.HasIndex(s => s.IsActive);
         });
     }
 }

--- a/api/src/Dtos/UpsertScratchPadDto.cs
+++ b/api/src/Dtos/UpsertScratchPadDto.cs
@@ -1,0 +1,3 @@
+namespace DailyWork.Api.Dtos;
+
+internal record UpsertScratchPadDto(string? Content);

--- a/api/src/Endpoints/ScratchPadEndpoints.cs
+++ b/api/src/Endpoints/ScratchPadEndpoints.cs
@@ -13,16 +13,16 @@ internal static class ScratchPadEndpoints
 
         group.MapGet("/", async (AppDbContext db) =>
         {
-            var entry = await db.ScratchPads.FirstOrDefaultAsync(s => s.IsActive);
+            var entry = await db.ScratchPads.SingleOrDefaultAsync(s => s.IsActive);
             if (entry is null)
-                return Results.Ok(new { content = (string?)null, isActive = true });
+                return Results.Ok(new { content = (string?)null, isActive = false });
 
             return Results.Ok(entry);
         });
 
         group.MapPut("/", async (AppDbContext db, UpsertScratchPadDto dto) =>
         {
-            var entry = await db.ScratchPads.FirstOrDefaultAsync(s => s.IsActive);
+            var entry = await db.ScratchPads.SingleOrDefaultAsync(s => s.IsActive);
 
             if (entry is not null)
             {
@@ -41,7 +41,7 @@ internal static class ScratchPadEndpoints
 
         group.MapPost("/clean", async (AppDbContext db) =>
         {
-            var entry = await db.ScratchPads.FirstOrDefaultAsync(s => s.IsActive);
+            var entry = await db.ScratchPads.SingleOrDefaultAsync(s => s.IsActive);
             if (entry is null)
                 return Results.NoContent();
 

--- a/api/src/Endpoints/ScratchPadEndpoints.cs
+++ b/api/src/Endpoints/ScratchPadEndpoints.cs
@@ -1,0 +1,56 @@
+using DailyWork.Api.Data;
+using DailyWork.Api.Dtos;
+using DailyWork.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyWork.Api.Endpoints;
+
+internal static class ScratchPadEndpoints
+{
+    public static RouteGroupBuilder MapScratchPadEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/scratchpad");
+
+        group.MapGet("/", async (AppDbContext db) =>
+        {
+            var entry = await db.ScratchPads.FirstOrDefaultAsync(s => s.IsActive);
+            if (entry is null)
+                return Results.Ok(new { content = (string?)null, isActive = true });
+
+            return Results.Ok(entry);
+        });
+
+        group.MapPut("/", async (AppDbContext db, UpsertScratchPadDto dto) =>
+        {
+            var entry = await db.ScratchPads.FirstOrDefaultAsync(s => s.IsActive);
+
+            if (entry is not null)
+            {
+                entry.Content = dto.Content;
+                entry.UpdatedAt = DateTime.UtcNow;
+            }
+            else
+            {
+                entry = new ScratchPad { Content = dto.Content };
+                db.ScratchPads.Add(entry);
+            }
+
+            await db.SaveChangesAsync();
+            return Results.Ok(entry);
+        });
+
+        group.MapPost("/clean", async (AppDbContext db) =>
+        {
+            var entry = await db.ScratchPads.FirstOrDefaultAsync(s => s.IsActive);
+            if (entry is null)
+                return Results.NoContent();
+
+            entry.IsActive = false;
+            entry.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        });
+
+        return group;
+    }
+}

--- a/api/src/Entities/ScratchPad.cs
+++ b/api/src/Entities/ScratchPad.cs
@@ -1,0 +1,10 @@
+namespace DailyWork.Api.Entities;
+
+internal class ScratchPad
+{
+    public int Id { get; set; }
+    public string? Content { get; set; }
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/api/src/Migrations/20260407190539_AddScratchPadTable.Designer.cs
+++ b/api/src/Migrations/20260407190539_AddScratchPadTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyWork.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DailyWork.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407190539_AddScratchPadTable")]
+    partial class AddScratchPadTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/src/Migrations/20260407190539_AddScratchPadTable.cs
+++ b/api/src/Migrations/20260407190539_AddScratchPadTable.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DailyWork.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScratchPadTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ScratchPads",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Content = table.Column<string>(type: "text", nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScratchPads", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScratchPads_IsActive",
+                table: "ScratchPads",
+                column: "IsActive");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ScratchPads");
+        }
+    }
+}

--- a/api/src/Migrations/20260407190539_AddScratchPadTable.cs
+++ b/api/src/Migrations/20260407190539_AddScratchPadTable.cs
@@ -31,7 +31,9 @@ namespace DailyWork.Api.Migrations
             migrationBuilder.CreateIndex(
                 name: "IX_ScratchPads_IsActive",
                 table: "ScratchPads",
-                column: "IsActive");
+                column: "IsActive",
+                unique: true,
+                filter: "\"IsActive\" = TRUE");
         }
 
         /// <inheritdoc />

--- a/api/src/Program.cs
+++ b/api/src/Program.cs
@@ -46,5 +46,6 @@ app.MapDefaultEndpoints();
 app.MapWorkItemEndpoints();
 app.MapReadWatchEndpoints();
 app.MapStandupEndpoints();
+app.MapScratchPadEndpoints();
 
 app.Run();

--- a/api/tests/ScratchPadEndpointTests.cs
+++ b/api/tests/ScratchPadEndpointTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DailyWork.Api.Tests.Fixtures;
+using Xunit;
+
+namespace DailyWork.Api.Tests;
+
+public class ScratchPadEndpointTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private sealed record ScratchPadResponse(int? Id, string? Content, bool? IsActive);
+
+    public ScratchPadEndpointTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetScratchPad_ReturnsNullContent_WhenNoActiveRecord()
+    {
+        // Arrange
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+
+        // Act
+        var response = await _client.GetAsync("/api/scratchpad");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var data = await response.Content.ReadFromJsonAsync<ScratchPadResponse>(JsonOptions);
+        Assert.NotNull(data);
+        Assert.Null(data.Content);
+    }
+
+    [Fact]
+    public async Task PutScratchPad_CreatesRecord_ReturnsOk()
+    {
+        // Arrange
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/api/scratchpad", new { content = "hello" });
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var data = await response.Content.ReadFromJsonAsync<ScratchPadResponse>(JsonOptions);
+        Assert.NotNull(data);
+        Assert.Equal("hello", data.Content);
+        Assert.True(data.IsActive);
+    }
+
+    [Fact]
+    public async Task GetScratchPad_ReturnsActiveContent_AfterSave()
+    {
+        // Arrange
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+        await _client.PutAsJsonAsync("/api/scratchpad", new { content = "persistent note" });
+
+        // Act
+        var response = await _client.GetAsync("/api/scratchpad");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var data = await response.Content.ReadFromJsonAsync<ScratchPadResponse>(JsonOptions);
+        Assert.NotNull(data);
+        Assert.Equal("persistent note", data.Content);
+    }
+
+    [Fact]
+    public async Task PutScratchPad_UpdatesContent_WhenActiveRecordExists()
+    {
+        // Arrange
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+        await _client.PutAsJsonAsync("/api/scratchpad", new { content = "first" });
+
+        // Act
+        await _client.PutAsJsonAsync("/api/scratchpad", new { content = "second" });
+
+        // Assert
+        var response = await _client.GetAsync("/api/scratchpad");
+        response.EnsureSuccessStatusCode();
+        var data = await response.Content.ReadFromJsonAsync<ScratchPadResponse>(JsonOptions);
+        Assert.NotNull(data);
+        Assert.Equal("second", data.Content);
+    }
+
+    [Fact]
+    public async Task PostScratchPadClean_ReturnsNoContent_WhenActiveExists()
+    {
+        // Arrange
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+        await _client.PutAsJsonAsync("/api/scratchpad", new { content = "some notes" });
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetScratchPad_ReturnsNullContent_AfterClean()
+    {
+        // Arrange
+        await _client.PutAsJsonAsync("/api/scratchpad", new { content = "some notes" });
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+
+        // Act
+        var response = await _client.GetAsync("/api/scratchpad");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var data = await response.Content.ReadFromJsonAsync<ScratchPadResponse>(JsonOptions);
+        Assert.NotNull(data);
+        Assert.Null(data.Content);
+    }
+
+    [Fact]
+    public async Task PostScratchPadClean_ReturnsNoContent_WhenNoActiveRecord()
+    {
+        // Arrange
+        await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/api/scratchpad/clean", new { });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -209,7 +209,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -258,7 +257,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1470,7 +1468,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2878,7 +2875,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -3448,7 +3444,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3461,7 +3456,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -3961,7 +3955,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3983,7 +3976,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4059,7 +4051,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -4148,7 +4139,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",

--- a/web/src/components/ScratchPad.vue
+++ b/web/src/components/ScratchPad.vue
@@ -39,6 +39,13 @@ function handleInput(event: Event) {
 
       <div class="flex items-center justify-between px-3 py-1 border-t border-border text-xs text-muted-foreground">
         <span>-- INSERT --</span>
+        <button
+          type="button"
+          class="text-muted-foreground hover:text-destructive transition-colors"
+          @click="store.clean()"
+        >
+          -- CLEAN --
+        </button>
         <span>{{ store.content.length }} chars</span>
       </div>
     </div>

--- a/web/src/components/ScratchPad.vue
+++ b/web/src/components/ScratchPad.vue
@@ -1,17 +1,30 @@
 <script setup lang="ts">
 import { useScratchPadStore } from '@/stores/scratchPad'
-import { useDebounceFn } from '@vueuse/core'
 
 const store = useScratchPadStore()
 
-const debouncedSave = useDebounceFn(() => {
-  store.save()
-}, 1000)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function cancelPendingSave() {
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer)
+    saveTimer = null
+  }
+}
 
 function handleInput(event: Event) {
   const value = (event.target as HTMLTextAreaElement).value
   store.setContent(value)
-  debouncedSave()
+  cancelPendingSave()
+  saveTimer = setTimeout(() => {
+    saveTimer = null
+    store.save()
+  }, 1000)
+}
+
+async function handleClean() {
+  cancelPendingSave()
+  await store.clean()
 }
 </script>
 
@@ -42,7 +55,7 @@ function handleInput(event: Event) {
         <button
           type="button"
           class="text-muted-foreground hover:text-destructive transition-colors"
-          @click="store.clean()"
+          @click="handleClean()"
         >
           -- CLEAN --
         </button>

--- a/web/src/stores/scratchPad.ts
+++ b/web/src/stores/scratchPad.ts
@@ -1,19 +1,13 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import client from '@/api/client'
-import { getWeekStart } from '@/utils/week'
 
 export const useScratchPadStore = defineStore('scratchPad', () => {
   const content = ref('')
-  const weekOf = ref(getWeekStart())
 
-  async function fetch(week?: string) {
-    const targetWeek = week ?? getWeekStart()
-    weekOf.value = targetWeek
+  async function fetch() {
     try {
-      const data = await client.get('/api/scratchpad', {
-        params: { weekOf: targetWeek }
-      }) as any
+      const data = await client.get('/api/scratchpad') as any
       content.value = data?.content ?? ''
     } catch {
       content.value = ''
@@ -21,15 +15,17 @@ export const useScratchPadStore = defineStore('scratchPad', () => {
   }
 
   async function save() {
-    await client.put('/api/scratchpad', {
-      content: content.value,
-      weekOf: weekOf.value
-    })
+    await client.put('/api/scratchpad', { content: content.value })
+  }
+
+  async function clean() {
+    await client.post('/api/scratchpad/clean', {})
+    content.value = ''
   }
 
   function setContent(value: string) {
     content.value = value
   }
 
-  return { content, weekOf, fetch, save, setContent }
+  return { content, fetch, save, clean, setContent }
 })

--- a/web/src/stores/scratchPad.ts
+++ b/web/src/stores/scratchPad.ts
@@ -19,8 +19,12 @@ export const useScratchPadStore = defineStore('scratchPad', () => {
   }
 
   async function clean() {
-    await client.post('/api/scratchpad/clean', {})
-    content.value = ''
+    try {
+      await client.post('/api/scratchpad/clean', {})
+      content.value = ''
+    } catch {
+      // Do not clear content if the request failed
+    }
   }
 
   function setContent(value: string) {

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -139,15 +139,15 @@ onMounted(() => {
       </main>
 
       <!-- Weekly View -->
-      <main v-if="view === 'weekly'" class="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
-        <div class="lg:col-span-2 space-y-6">
-          <WeekOverview />
-          <DailyTasks />
-          <ReadWatchList :default-show-all="true" />
+      <main v-if="view === 'weekly'" class="space-y-6 mt-6">
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div class="lg:col-span-2"><WeekOverview /></div>
+          <div><StatsPanel /></div>
         </div>
-        <div class="space-y-6">
-          <StatsPanel />
+        <DailyTasks />
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <ScratchPad />
+          <ReadWatchList :default-show-all="true" />
         </div>
       </main>
 


### PR DESCRIPTION
Three correctness issues in the ScratchPad API and a UI data-loss bug in the frontend store.

## API (`ScratchPadEndpoints.cs`)

- **`FirstOrDefaultAsync` → `SingleOrDefaultAsync`** on all three endpoints (`GET`, `PUT`, `POST /clean`). The unique partial index on `IsActive = TRUE` guarantees at most one active row; `SingleOrDefaultAsync` enforces that invariant at the query layer and fails fast on corruption rather than silently picking an arbitrary row.
- **GET no-record response**: `isActive` was incorrectly returned as `true` when no active record exists — changed to `false`.

## Frontend (`scratchPad.ts`, `ScratchPad.vue`)

- **`clean()` error guard**: content was cleared unconditionally before awaiting the POST. Wrapped in `try/catch`; `content` is only reset on success.
- **Debounced-save race**: a pending auto-save could fire after `clean()`, recreating an empty active record and undoing the archive. Replaced `useDebounceFn` (VueUse v14 return type doesn't expose `.cancel()`) with a manual `setTimeout`/`clearTimeout` debounce; `handleClean()` cancels any pending save before calling `store.clean()`.