### PR TITLE
feat(web,api): implement full learning panel with consume/review flow

### DIFF
--- a/api/src/Data/AppDbContext.cs
+++ b/api/src/Data/AppDbContext.cs
@@ -22,6 +22,8 @@ internal class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(
         modelBuilder.Entity<ReadWatchItem>(e =>
         {
             e.HasIndex(r => r.Date);
+            e.HasIndex(r => r.IsActive);
+            e.HasIndex(r => r.WeekConsumed);
         });
 
         modelBuilder.Entity<UpdateComm>(e =>

--- a/api/src/Dtos/ReadWatchItemDtos.cs
+++ b/api/src/Dtos/ReadWatchItemDtos.cs
@@ -1,10 +1,12 @@
 namespace DailyWork.Api.Dtos;
 
-internal record CreateReadWatchItemDto(string Title, string Url, DateOnly? Date);
+internal record CreateReadWatchItemDto(string Text, string? Type, DateOnly? Date);
 
 internal record UpdateReadWatchItemDto
 {
     public string? Title { get; init; }
     public string? Url { get; init; }
-    public bool? IsDone { get; init; }
+    public bool? IsActive { get; init; }
 }
+
+internal record ConsumeReadWatchItemDto(bool WorthSharing, string Notes, DateOnly WeekOf);

--- a/api/src/Endpoints/ReadWatchEndpoints.cs
+++ b/api/src/Endpoints/ReadWatchEndpoints.cs
@@ -40,7 +40,7 @@ internal static partial class ReadWatchEndpoints
 		group.MapPost("/", async (AppDbContext db, IDateTimeProvider dateTime, CreateReadWatchItemDto dto) =>
 		{
 			var d = dto.Date ?? dateTime.UtcToday;
-			var count = await db.ReadWatchItems.CountAsync(r => r.Date == d);
+			var count = await db.ReadWatchItems.CountAsync(r => r.Date == d && r.IsActive && !r.IsDone);
 			if (count >= 5)
 				return Results.Problem("Maximum of 5 read/watch items per day.", statusCode: 400);
 
@@ -86,7 +86,8 @@ internal static partial class ReadWatchEndpoints
 			item.IsActive = false;
 			item.WorthSharing = dto.WorthSharing;
 			item.Notes = dto.Notes;
-			item.WeekConsumed = dto.WeekOf;
+			if (item.WeekConsumed is null)
+				item.WeekConsumed = dto.WeekOf;
 
 			await db.SaveChangesAsync();
 			return Results.Ok(item);

--- a/api/src/Endpoints/ReadWatchEndpoints.cs
+++ b/api/src/Endpoints/ReadWatchEndpoints.cs
@@ -1,21 +1,38 @@
+using System.Text.RegularExpressions;
 using DailyWork.Api.Data;
 using DailyWork.Api.Dtos;
 using DailyWork.Api.Entities;
+using DailyWork.Api.Enums;
 using Microsoft.EntityFrameworkCore;
 
 namespace DailyWork.Api.Endpoints;
 
-internal static class ReadWatchEndpoints
+internal static partial class ReadWatchEndpoints
 {
+	[GeneratedRegex(@"(https?://\S+)", RegexOptions.Compiled)]
+	private static partial Regex UrlRegex();
+
 	public static RouteGroupBuilder MapReadWatchEndpoints(this WebApplication app)
 	{
 		var group = app.MapGroup("/api/read-watch");
 
-		group.MapGet("/", async (AppDbContext db, IDateTimeProvider dateTime, DateOnly? date) =>
+		group.MapGet("/", async (AppDbContext db, IDateTimeProvider dateTime, DateOnly? date, DateOnly? weekOf) =>
 		{
+			if (weekOf is not null)
+			{
+				// Weekly view: all not-done items + consumed items from this week
+				return await db.ReadWatchItems
+					.AsNoTracking()
+					.Where(r => !r.IsDone || r.WeekConsumed == weekOf)
+					.OrderBy(r => r.CreatedAt)
+					.ToListAsync();
+			}
+
+			// Daily view: active, not-done items for the given date
 			var d = date ?? dateTime.UtcToday;
 			return await db.ReadWatchItems
-				.Where(r => r.Date == d)
+				.AsNoTracking()
+				.Where(r => r.Date == d && r.IsActive && !r.IsDone)
 				.OrderBy(r => r.CreatedAt)
 				.ToListAsync();
 		});
@@ -25,15 +42,17 @@ internal static class ReadWatchEndpoints
 			var d = dto.Date ?? dateTime.UtcToday;
 			var count = await db.ReadWatchItems.CountAsync(r => r.Date == d);
 			if (count >= 5)
-			{
 				return Results.Problem("Maximum of 5 read/watch items per day.", statusCode: 400);
-			}
+
+			var (title, url) = ParseTextForUrl(dto.Text);
+			var type = Enum.TryParse<ReadWatchType>(dto.Type, ignoreCase: true, out var parsed) ? parsed : ReadWatchType.Read;
 
 			var item = new ReadWatchItem
 			{
-				Title = dto.Title,
-				Url = dto.Url,
-				Date = d
+				Title = title,
+				Url = url,
+				Type = type,
+				Date = d,
 			};
 			db.ReadWatchItems.Add(item);
 			await db.SaveChangesAsync();
@@ -44,22 +63,30 @@ internal static class ReadWatchEndpoints
 		{
 			var item = await db.ReadWatchItems.FindAsync(id);
 			if (item is null)
-			{
 				return Results.NotFound();
-			}
 
 			if (dto.Title is not null)
-			{
 				item.Title = dto.Title;
-			}
 			if (dto.Url is not null)
-			{
 				item.Url = dto.Url;
-			}
-			if (dto.IsDone.HasValue)
-			{
-				item.IsDone = dto.IsDone.Value;
-			}
+			if (dto.IsActive.HasValue)
+				item.IsActive = dto.IsActive.Value;
+
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
+		});
+
+		group.MapPut("/{id}/consume", async (AppDbContext db, int id, ConsumeReadWatchItemDto dto) =>
+		{
+			var item = await db.ReadWatchItems.FindAsync(id);
+			if (item is null)
+				return Results.NotFound();
+
+			item.IsDone = true;
+			item.IsActive = false;
+			item.WorthSharing = dto.WorthSharing;
+			item.Notes = dto.Notes;
+			item.WeekConsumed = dto.WeekOf;
 
 			await db.SaveChangesAsync();
 			return Results.Ok(item);
@@ -69,9 +96,7 @@ internal static class ReadWatchEndpoints
 		{
 			var item = await db.ReadWatchItems.FindAsync(id);
 			if (item is null)
-			{
 				return Results.NotFound();
-			}
 
 			db.ReadWatchItems.Remove(item);
 			await db.SaveChangesAsync();
@@ -79,5 +104,21 @@ internal static class ReadWatchEndpoints
 		});
 
 		return group;
+	}
+
+	internal static (string Title, string Url) ParseTextForUrl(string text)
+	{
+		var match = UrlRegex().Match(text);
+		if (!match.Success)
+			return (text.Trim(), string.Empty);
+
+		var url = match.Value;
+		var title = text.Replace(url, "").Trim();
+
+		// If the text was only a URL, use the URL as the title
+		if (string.IsNullOrWhiteSpace(title))
+			return (url, url);
+
+		return (title, url);
 	}
 }

--- a/api/src/Entities/ReadWatchItem.cs
+++ b/api/src/Entities/ReadWatchItem.cs
@@ -1,3 +1,5 @@
+using DailyWork.Api.Enums;
+
 namespace DailyWork.Api.Entities;
 
 internal class ReadWatchItem
@@ -5,7 +7,12 @@ internal class ReadWatchItem
     public int Id { get; set; }
     public required string Title { get; set; }
     public required string Url { get; set; }
+    public ReadWatchType? Type { get; set; }
     public bool IsDone { get; set; }
+    public bool IsActive { get; set; } = true;
+    public bool? WorthSharing { get; set; }
+    public string? Notes { get; set; }
     public DateOnly Date { get; set; }
+    public DateOnly? WeekConsumed { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/api/src/Entities/ReadWatchItem.cs
+++ b/api/src/Entities/ReadWatchItem.cs
@@ -7,7 +7,7 @@ internal class ReadWatchItem
     public int Id { get; set; }
     public required string Title { get; set; }
     public required string Url { get; set; }
-    public ReadWatchType? Type { get; set; }
+    public ReadWatchType Type { get; set; } = ReadWatchType.Read;
     public bool IsDone { get; set; }
     public bool IsActive { get; set; } = true;
     public bool? WorthSharing { get; set; }

--- a/api/src/Enums/ReadWatchType.cs
+++ b/api/src/Enums/ReadWatchType.cs
@@ -1,0 +1,8 @@
+namespace DailyWork.Api.Enums;
+
+internal enum ReadWatchType
+{
+    Read = 1,
+    Watch = 2,
+    Learn = 3,
+}

--- a/api/src/Migrations/20260408133538_AddLearningFieldsToReadWatchItems.Designer.cs
+++ b/api/src/Migrations/20260408133538_AddLearningFieldsToReadWatchItems.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyWork.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DailyWork.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408133538_AddLearningFieldsToReadWatchItems")]
+    partial class AddLearningFieldsToReadWatchItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/src/Migrations/20260408133538_AddLearningFieldsToReadWatchItems.cs
+++ b/api/src/Migrations/20260408133538_AddLearningFieldsToReadWatchItems.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyWork.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLearningFieldsToReadWatchItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "ReadWatchItems",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "ReadWatchItems",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Type",
+                table: "ReadWatchItems",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "WeekConsumed",
+                table: "ReadWatchItems",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "WorthSharing",
+                table: "ReadWatchItems",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadWatchItems_IsActive",
+                table: "ReadWatchItems",
+                column: "IsActive");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReadWatchItems_WeekConsumed",
+                table: "ReadWatchItems",
+                column: "WeekConsumed");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ReadWatchItems_IsActive",
+                table: "ReadWatchItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReadWatchItems_WeekConsumed",
+                table: "ReadWatchItems");
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "ReadWatchItems");
+
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "ReadWatchItems");
+
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "ReadWatchItems");
+
+            migrationBuilder.DropColumn(
+                name: "WeekConsumed",
+                table: "ReadWatchItems");
+
+            migrationBuilder.DropColumn(
+                name: "WorthSharing",
+                table: "ReadWatchItems");
+        }
+    }
+}

--- a/api/src/Migrations/20260408200854_MakeReadWatchTypeNonNullable.Designer.cs
+++ b/api/src/Migrations/20260408200854_MakeReadWatchTypeNonNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyWork.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DailyWork.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408200854_MakeReadWatchTypeNonNullable")]
+    partial class MakeReadWatchTypeNonNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/src/Migrations/20260408200854_MakeReadWatchTypeNonNullable.cs
+++ b/api/src/Migrations/20260408200854_MakeReadWatchTypeNonNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyWork.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeReadWatchTypeNonNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Type",
+                table: "ReadWatchItems",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Type",
+                table: "ReadWatchItems",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+    }
+}

--- a/api/tests/ReadWatchEndpointTests.cs
+++ b/api/tests/ReadWatchEndpointTests.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DailyWork.Api.Entities;
+using DailyWork.Api.Tests.Fixtures;
+using Xunit;
+
+namespace DailyWork.Api.Tests;
+
+public class ReadWatchEndpointTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public ReadWatchEndpointTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task PostReadWatch_ParsesUrlFromText_ReturnsCreated()
+    {
+        var response = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "Interesting article https://example.com/article",
+            Type = "Read",
+            Date = "2019-01-01"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var item = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(item);
+        Assert.Equal("Interesting article", item.Title);
+        Assert.Equal("https://example.com/article", item.Url);
+    }
+
+    [Fact]
+    public async Task PostReadWatch_NoUrl_StoresTitleOnly()
+    {
+        var response = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "Learn about design patterns",
+            Type = "Learn",
+            Date = "2019-01-02"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var item = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(item);
+        Assert.Equal("Learn about design patterns", item.Title);
+        Assert.Equal(string.Empty, item.Url);
+    }
+
+    [Fact]
+    public async Task PostReadWatch_UrlOnly_UsesUrlAsTitle()
+    {
+        var response = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "https://example.com/video",
+            Type = "Watch",
+            Date = "2019-01-03"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var item = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(item);
+        Assert.Equal("https://example.com/video", item.Title);
+        Assert.Equal("https://example.com/video", item.Url);
+    }
+
+    [Fact]
+    public async Task PostReadWatch_StoresType_ReturnsInResponse()
+    {
+        var response = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "TypeScript deep dive",
+            Type = "Learn",
+            Date = "2019-01-04"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var item = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(item);
+        Assert.Equal("Learn", item.Type.ToString());
+    }
+
+    [Fact]
+    public async Task GetReadWatch_ByDate_ReturnsOnlyActiveNotDone()
+    {
+        var testDate = "2019-02-01";
+
+        // Arrange — create an active item and a backlogged item
+        await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "active-date-filter-test",
+            Type = "Read",
+            Date = testDate
+        });
+
+        var backlogResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "backlog-date-filter-test",
+            Type = "Read",
+            Date = testDate
+        });
+        var backlogItem = await backlogResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        await _client.PutAsJsonAsync($"/api/read-watch/{backlogItem!.Id}", new { IsActive = false });
+
+        // Act
+        var response = await _client.GetAsync($"/api/read-watch?date={testDate}");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var items = await response.Content.ReadFromJsonAsync<List<ReadWatchItem>>(JsonOptions);
+        Assert.NotNull(items);
+        Assert.Contains(items, i => i.Title == "active-date-filter-test");
+        Assert.DoesNotContain(items, i => i.Title == "backlog-date-filter-test");
+    }
+
+    [Fact]
+    public async Task GetReadWatch_ByWeekOf_ReturnsAllNotDoneAndConsumedThatWeek()
+    {
+        var testDate = "2019-03-06"; // Wednesday
+        var testWeekOf = "2019-03-04"; // Monday
+
+        // Arrange — create an active item
+        await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "weekof-active-test",
+            Type = "Read",
+            Date = testDate
+        });
+
+        // Create and consume an item this week
+        var consumeResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "weekof-consumed-test",
+            Type = "Read",
+            Date = testDate
+        });
+        var consumeItem = await consumeResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        await _client.PutAsJsonAsync($"/api/read-watch/{consumeItem!.Id}/consume", new
+        {
+            WorthSharing = true,
+            Notes = "Great stuff",
+            WeekOf = testWeekOf
+        });
+
+        // Act
+        var response = await _client.GetAsync($"/api/read-watch?weekOf={testWeekOf}");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var items = await response.Content.ReadFromJsonAsync<List<ReadWatchItem>>(JsonOptions);
+        Assert.NotNull(items);
+        Assert.Contains(items, i => i.Title == "weekof-active-test");
+        Assert.Contains(items, i => i.Title == "weekof-consumed-test");
+    }
+
+    [Fact]
+    public async Task GetReadWatch_ByWeekOf_ExcludesConsumedOtherWeeks()
+    {
+        var otherWeekOf = "2019-04-01"; // a different week
+        var queryWeekOf = "2019-05-06"; // the week we query
+
+        // Arrange — create and consume an item for a different week
+        var resp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "other-week-consumed-test",
+            Type = "Read",
+            Date = "2019-04-02"
+        });
+        var item = await resp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        await _client.PutAsJsonAsync($"/api/read-watch/{item!.Id}/consume", new
+        {
+            WorthSharing = false,
+            Notes = "Old item",
+            WeekOf = otherWeekOf
+        });
+
+        // Act
+        var response = await _client.GetAsync($"/api/read-watch?weekOf={queryWeekOf}");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var items = await response.Content.ReadFromJsonAsync<List<ReadWatchItem>>(JsonOptions);
+        Assert.NotNull(items);
+        Assert.DoesNotContain(items, i => i.Title == "other-week-consumed-test");
+    }
+
+    [Fact]
+    public async Task PutReadWatch_SetsIsActiveFalse_BacklogsItem()
+    {
+        // Arrange
+        var createResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "backlog-toggle-test",
+            Type = "Read",
+            Date = "2019-06-01"
+        });
+        var created = await createResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/read-watch/{created!.Id}", new { IsActive = false });
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var updated = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(updated);
+        Assert.False(updated.IsActive);
+    }
+
+    [Fact]
+    public async Task PutReadWatch_SetsIsActiveTrue_RestoresFromBacklog()
+    {
+        // Arrange
+        var createResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "restore-toggle-test",
+            Type = "Read",
+            Date = "2019-07-01"
+        });
+        var created = await createResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        await _client.PutAsJsonAsync($"/api/read-watch/{created!.Id}", new { IsActive = false });
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/read-watch/{created.Id}", new { IsActive = true });
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var updated = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(updated);
+        Assert.True(updated.IsActive);
+    }
+
+    [Fact]
+    public async Task PutConsumeReadWatch_SetsAllFields()
+    {
+        var testWeekOf = "2019-08-05";
+
+        // Arrange
+        var createResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "consume-fields-test",
+            Type = "Read",
+            Date = "2019-08-07"
+        });
+        var created = await createResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+
+        // Act
+        var response = await _client.PutAsJsonAsync($"/api/read-watch/{created!.Id}/consume", new
+        {
+            WorthSharing = true,
+            Notes = "Very insightful article",
+            WeekOf = testWeekOf
+        });
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var consumed = await response.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(consumed);
+        Assert.True(consumed.IsDone);
+        Assert.False(consumed.IsActive);
+        Assert.True(consumed.WorthSharing);
+        Assert.Equal("Very insightful article", consumed.Notes);
+        Assert.Equal(testWeekOf, consumed.WeekConsumed?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task PutConsumeReadWatch_ReturnsNotFound_WhenMissing()
+    {
+        var response = await _client.PutAsJsonAsync("/api/read-watch/99999/consume", new
+        {
+            WorthSharing = false,
+            Notes = "N/A",
+            WeekOf = "2019-09-02"
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/api/tests/ReadWatchEndpointTests.cs
+++ b/api/tests/ReadWatchEndpointTests.cs
@@ -283,4 +283,78 @@ public class ReadWatchEndpointTests : IClassFixture<CustomWebApplicationFactory>
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task PostReadWatch_EnforcesLimit_IgnoringBacklogItems()
+    {
+        var testDate = "2019-11-01";
+
+        // Arrange — create 5 items
+        var createdIds = new List<int>();
+        for (var i = 0; i < 5; i++)
+        {
+            var resp = await _client.PostAsJsonAsync("/api/read-watch", new
+            {
+                Text = $"limit-test-item-{i}",
+                Type = "Read",
+                Date = testDate
+            });
+            Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+            var item = await resp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+            createdIds.Add(item!.Id);
+        }
+
+        // Backlog one of them — active count drops to 4
+        await _client.PutAsJsonAsync($"/api/read-watch/{createdIds[0]}", new { IsActive = false });
+
+        // Act — add a 6th item; active count is 4 so it should succeed
+        var sixthResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "limit-test-sixth-item",
+            Type = "Read",
+            Date = testDate
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, sixthResp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PutConsumeReadWatch_PreservesWeekConsumed_WhenReconsumed()
+    {
+        var originalWeekOf = "2019-10-07";
+        var newWeekOf = "2019-10-14";
+
+        // Arrange — create and consume an item in week A
+        var createResp = await _client.PostAsJsonAsync("/api/read-watch", new
+        {
+            Text = "preserve-week-consumed-test",
+            Type = "Read",
+            Date = "2019-10-09"
+        });
+        var created = await createResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+
+        await _client.PutAsJsonAsync($"/api/read-watch/{created!.Id}/consume", new
+        {
+            WorthSharing = true,
+            Notes = "Original notes",
+            WeekOf = originalWeekOf
+        });
+
+        // Act — consume again with a different week (simulating a review save)
+        var reviewResp = await _client.PutAsJsonAsync($"/api/read-watch/{created.Id}/consume", new
+        {
+            WorthSharing = false,
+            Notes = "Updated notes",
+            WeekOf = newWeekOf
+        });
+
+        // Assert — WeekConsumed must still reflect the original week
+        reviewResp.EnsureSuccessStatusCode();
+        var reviewed = await reviewResp.Content.ReadFromJsonAsync<ReadWatchItem>(JsonOptions);
+        Assert.NotNull(reviewed);
+        Assert.Equal(originalWeekOf, reviewed.WeekConsumed?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal("Updated notes", reviewed.Notes);
+        Assert.False(reviewed.WorthSharing);
+    }
 }

--- a/web/src/components/LearningCompleteModal.spec.ts
+++ b/web/src/components/LearningCompleteModal.spec.ts
@@ -1,4 +1,4 @@
-import { mount, VueWrapper } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import LearningCompleteModal from './LearningCompleteModal.vue'
 import type { ReadWatchItem } from '@/types'

--- a/web/src/components/LearningCompleteModal.spec.ts
+++ b/web/src/components/LearningCompleteModal.spec.ts
@@ -1,0 +1,177 @@
+import { mount, VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import LearningCompleteModal from './LearningCompleteModal.vue'
+import type { ReadWatchItem } from '@/types'
+
+const createMockItem = (overrides: Partial<ReadWatchItem> = {}): ReadWatchItem => ({
+  id: 1,
+  title: 'Test article',
+  url: '',
+  type: 'Read',
+  isDone: false,
+  isActive: true,
+  worthSharing: null,
+  notes: null,
+  weekConsumed: null,
+  date: '2026-04-08',
+  ...overrides,
+})
+
+// Teleport renders outside the wrapper, so query from document.body
+function findTestId(testId: string) {
+  return document.body.querySelector(`[data-testid="${testId}"]`)
+}
+
+async function mountModal(props: {
+  isOpen: boolean
+  item: ReadWatchItem | null
+  mode?: 'consume' | 'review'
+}) {
+  const wrapper = mount(LearningCompleteModal, {
+    props,
+    attachTo: document.body,
+  })
+  await nextTick()
+  return wrapper
+}
+
+describe('LearningCompleteModal', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('LearningCompleteModal_RendersWhenOpen', async () => {
+    await mountModal({
+      isOpen: true,
+      item: createMockItem(),
+    })
+
+    expect(findTestId('learning-complete-modal')).not.toBeNull()
+  })
+
+  it('LearningCompleteModal_DoesNotRender_WhenClosed', async () => {
+    await mountModal({
+      isOpen: false,
+      item: createMockItem(),
+    })
+
+    expect(findTestId('learning-complete-modal')).toBeNull()
+  })
+
+  it('LearningCompleteModal_DisablesSubmit_WhenFieldsEmpty', async () => {
+    await mountModal({
+      isOpen: true,
+      item: createMockItem(),
+    })
+
+    const submitBtn = findTestId('submit-btn') as HTMLButtonElement
+    expect(submitBtn).not.toBeNull()
+    expect(submitBtn.disabled).toBe(true)
+  })
+
+  it('LearningCompleteModal_EmitsSubmit_WithFormData', async () => {
+    const wrapper = await mountModal({
+      isOpen: true,
+      item: createMockItem(),
+    })
+
+    // Select "Yes" for worth sharing
+    const yesRadio = findTestId('worth-sharing-yes') as HTMLInputElement
+    yesRadio.click()
+    await nextTick()
+
+    // Fill notes
+    const notesInput = findTestId('notes-input') as HTMLTextAreaElement
+    notesInput.value = 'Great insights on testing'
+    notesInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    // Submit
+    const submitBtn = findTestId('submit-btn') as HTMLButtonElement
+    submitBtn.click()
+    await nextTick()
+
+    expect(wrapper.emitted('submit')).toBeTruthy()
+    expect(wrapper.emitted('submit')![0]).toEqual([
+      { worthSharing: true, notes: 'Great insights on testing' },
+    ])
+  })
+
+  it('LearningCompleteModal_EmitsClose_OnCancel', async () => {
+    const wrapper = await mountModal({
+      isOpen: true,
+      item: createMockItem(),
+    })
+
+    const cancelBtn = findTestId('cancel-btn') as HTMLButtonElement
+    cancelBtn.click()
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('LearningCompleteModal_PopulatesExistingData_InReviewMode', async () => {
+    const item = createMockItem({
+      worthSharing: true,
+      notes: 'Previous notes',
+    })
+
+    await mountModal({
+      isOpen: true,
+      item,
+      mode: 'review',
+    })
+
+    const notesInput = findTestId('notes-input') as HTMLTextAreaElement
+    expect(notesInput.value).toBe('Previous notes')
+
+    const yesRadio = findTestId('worth-sharing-yes') as HTMLInputElement
+    expect(yesRadio.checked).toBe(true)
+  })
+
+  it('LearningCompleteModal_ShowsItemTitle', async () => {
+    await mountModal({
+      isOpen: true,
+      item: createMockItem({ title: 'My Learning Item' }),
+    })
+
+    const modal = findTestId('learning-complete-modal')
+    expect(modal?.textContent).toContain('My Learning Item')
+  })
+
+  it('LearningCompleteModal_ShowsTitleAsLink_WhenUrlPresent', async () => {
+    await mountModal({
+      isOpen: true,
+      item: createMockItem({
+        title: 'Linked item',
+        url: 'https://example.com',
+      }),
+    })
+
+    const link = document.body.querySelector('a[href="https://example.com"]')
+    expect(link).not.toBeNull()
+    expect(link?.textContent).toContain('Linked item')
+  })
+
+  it('LearningCompleteModal_ShowsCompleteButton_InConsumeMode', async () => {
+    await mountModal({
+      isOpen: true,
+      item: createMockItem(),
+      mode: 'consume',
+    })
+
+    const submitBtn = findTestId('submit-btn')
+    expect(submitBtn?.textContent).toContain('complete')
+  })
+
+  it('LearningCompleteModal_ShowsSaveButton_InReviewMode', async () => {
+    await mountModal({
+      isOpen: true,
+      item: createMockItem({ worthSharing: false, notes: 'test' }),
+      mode: 'review',
+    })
+
+    const submitBtn = findTestId('submit-btn')
+    expect(submitBtn?.textContent).toContain('save')
+  })
+})

--- a/web/src/components/LearningCompleteModal.vue
+++ b/web/src/components/LearningCompleteModal.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import type { ReadWatchItem } from '@/types'
+
+const { isOpen, item, mode = 'consume' } = defineProps<{
+  isOpen: boolean
+  item: ReadWatchItem | null
+  mode?: 'consume' | 'review'
+}>()
+
+const emit = defineEmits<{
+  submit: [data: { worthSharing: boolean; notes: string }]
+  close: []
+}>()
+
+const worthSharing = ref<boolean | null>(null)
+const notes = ref('')
+
+const isValid = computed(() => worthSharing.value !== null && notes.value.trim().length > 0)
+
+function resetForm() {
+  if (isOpen && item) {
+    if (mode === 'review' && item.worthSharing !== null) {
+      worthSharing.value = item.worthSharing
+      notes.value = item.notes ?? ''
+    } else {
+      worthSharing.value = null
+      notes.value = ''
+    }
+  }
+}
+
+watch(() => isOpen, resetForm, { immediate: true })
+
+function handleSubmit() {
+  if (worthSharing.value === null || !notes.value.trim()) return
+  emit('submit', { worthSharing: worthSharing.value, notes: notes.value.trim() })
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (!isOpen) return
+  if (e.key === 'Escape') emit('close')
+}
+
+onMounted(() => document.addEventListener('keydown', handleKeydown))
+onUnmounted(() => document.removeEventListener('keydown', handleKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isOpen && item"
+      data-testid="learning-complete-modal"
+      class="fixed inset-0 z-50 flex items-center justify-center"
+    >
+      <!-- Backdrop -->
+      <div class="absolute inset-0 bg-black/60" @click="emit('close')" />
+
+      <!-- Modal -->
+      <div class="relative w-[40vw] min-w-[360px] max-h-[60vh] bg-card border border-border flex flex-col">
+        <!-- Header -->
+        <div class="border-b border-border p-4">
+          <div class="flex items-center gap-2 text-sm text-muted-foreground mb-2">
+            <span class="text-primary">$</span>
+            <span>{{ mode === 'consume' ? 'complete' : 'review' }} --learning</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <a
+              v-if="item.url"
+              :href="item.url"
+              target="_blank"
+              rel="noopener"
+              class="text-foreground hover:underline text-sm font-medium"
+            >
+              {{ item.title }}
+            </a>
+            <span v-else class="text-foreground text-sm font-medium">
+              {{ item.title }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto p-4 space-y-4">
+          <!-- Worth sharing radio -->
+          <div>
+            <div class="flex items-center gap-2 mb-2">
+              <span class="text-accent">&gt;&gt;&gt;</span>
+              <span class="text-muted-foreground text-xs uppercase tracking-wider">
+                Worth sharing this week?
+              </span>
+            </div>
+            <div class="flex gap-4 ml-6">
+              <label class="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  v-model="worthSharing"
+                  type="radio"
+                  :value="true"
+                  data-testid="worth-sharing-yes"
+                  class="accent-primary"
+                />
+                <span class="text-foreground">Yes</span>
+              </label>
+              <label class="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  v-model="worthSharing"
+                  type="radio"
+                  :value="false"
+                  data-testid="worth-sharing-no"
+                  class="accent-primary"
+                />
+                <span class="text-foreground">No</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Notes textarea -->
+          <div>
+            <div class="flex items-center gap-2 mb-2">
+              <span class="text-accent">&gt;&gt;&gt;</span>
+              <span class="text-muted-foreground text-xs uppercase tracking-wider">
+                Findings / Notes
+              </span>
+            </div>
+            <textarea
+              v-model="notes"
+              data-testid="notes-input"
+              class="w-full bg-input border border-border text-foreground text-sm p-2 min-h-[120px] resize-y outline-none focus:border-primary"
+              placeholder="What did you learn? Any key takeaways..."
+            />
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="border-t border-border p-4 flex items-center justify-end gap-2">
+          <button
+            data-testid="cancel-btn"
+            class="text-muted-foreground hover:text-foreground text-sm px-3 py-1"
+            @click="emit('close')"
+          >
+            [cancel]
+          </button>
+          <button
+            data-testid="submit-btn"
+            :disabled="!isValid"
+            :class="[
+              'text-sm px-3 py-1 border border-border',
+              isValid
+                ? 'bg-primary text-primary-foreground hover:opacity-90'
+                : 'bg-secondary text-muted-foreground cursor-not-allowed',
+            ]"
+            @click="handleSubmit"
+          >
+            [{{ mode === 'consume' ? 'complete' : 'save' }}]
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/web/src/components/ReadWatchList.vue
+++ b/web/src/components/ReadWatchList.vue
@@ -62,7 +62,7 @@ async function handleModalSubmit(data: { worthSharing: boolean; notes: string })
   await store.consume(modalItem.value.id, {
     worthSharing: data.worthSharing,
     notes: data.notes,
-    weekOf: getWeekStart(),
+    weekOf: modalItem.value.weekConsumed ?? getWeekStart(),
   })
   modalOpen.value = false
   modalItem.value = null

--- a/web/src/components/ReadWatchList.vue
+++ b/web/src/components/ReadWatchList.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ref, nextTick } from 'vue'
 import { useReadWatchStore } from '@/stores/readWatch'
+import type { ReadWatchItem } from '@/types'
 import ReadingItemRow from './ReadingItemRow.vue'
+import LearningCompleteModal from './LearningCompleteModal.vue'
+import { getWeekStart } from '@/utils/week'
 
 const { defaultShowAll = false } = defineProps<{
   defaultShowAll?: boolean
@@ -9,11 +12,16 @@ const { defaultShowAll = false } = defineProps<{
 
 const store = useReadWatchStore()
 
-const newTitle = ref('')
-const newType = ref<'read' | 'watch' | 'learn'>('read')
+const newText = ref('')
+const newType = ref<'Read' | 'Watch' | 'Learn'>('Read')
 const isAdding = ref(false)
 const showAll = ref(defaultShowAll)
 const inputRef = ref<HTMLInputElement | null>(null)
+
+// Modal state
+const modalItem = ref<ReadWatchItem | null>(null)
+const modalMode = ref<'consume' | 'review'>('consume')
+const modalOpen = ref(false)
 
 function startAdding() {
   isAdding.value = true
@@ -21,25 +29,52 @@ function startAdding() {
 }
 
 function cancelAdd() {
-  newTitle.value = ''
+  newText.value = ''
   isAdding.value = false
 }
 
 async function handleAddItem() {
-  var title = newTitle.value.trim()
-  if (!title) return
-  await store.create(title, '', newType.value)
-  newTitle.value = ''
+  var text = newText.value.trim()
+  if (!text) return
+  await store.create(text, newType.value)
+  newText.value = ''
   isAdding.value = false
 }
 
-async function handleToggle(id: number) {
+function handleConsume(id: number) {
   var item = store.items.find((i) => i.id === id)
-  if (item) await store.update(id, { isDone: !item.isDone })
+  if (!item) return
+  modalItem.value = item
+  modalMode.value = 'consume'
+  modalOpen.value = true
 }
 
-function handleToggleActive(id: number) {
-  store.toggleActive(id)
+function handleReview(id: number) {
+  var item = store.items.find((i) => i.id === id)
+  if (!item) return
+  modalItem.value = item
+  modalMode.value = 'review'
+  modalOpen.value = true
+}
+
+async function handleModalSubmit(data: { worthSharing: boolean; notes: string }) {
+  if (!modalItem.value) return
+  await store.consume(modalItem.value.id, {
+    worthSharing: data.worthSharing,
+    notes: data.notes,
+    weekOf: getWeekStart(),
+  })
+  modalOpen.value = false
+  modalItem.value = null
+}
+
+function handleModalClose() {
+  modalOpen.value = false
+  modalItem.value = null
+}
+
+async function handleToggleActive(id: number) {
+  await store.toggleActive(id)
 }
 
 async function handleDelete(id: number) {
@@ -59,7 +94,7 @@ async function handleDelete(id: number) {
         <div class="flex items-center gap-2">
           <span class="text-accent">&gt;&gt;&gt;</span>
           <span class="text-muted-foreground text-xs uppercase tracking-wider">
-            Active Queue ({{ store.activeItems.length }}/5)
+            Active Queue ({{ store.activeItems.length }})
           </span>
         </div>
         <button
@@ -78,9 +113,9 @@ async function handleDelete(id: number) {
           v-for="item in store.activeItems"
           :key="item.id"
           :item="item"
-          :show-toggle="true"
-          @toggle="handleToggle"
+          @consume="handleConsume"
           @toggle-active="handleToggleActive"
+          @review="handleReview"
           @delete="handleDelete"
         />
       </div>
@@ -91,16 +126,16 @@ async function handleDelete(id: number) {
           v-model="newType"
           class="bg-secondary text-secondary-foreground text-xs px-1 py-0.5 border border-border"
         >
-          <option value="read">READ</option>
-          <option value="watch">WATCH</option>
-          <option value="learn">LEARN</option>
+          <option value="Read">READ</option>
+          <option value="Watch">WATCH</option>
+          <option value="Learn">LEARN</option>
         </select>
         <input
           ref="inputRef"
-          v-model="newTitle"
+          v-model="newText"
           type="text"
           class="flex-1 bg-transparent border-none outline-none text-foreground text-sm"
-          placeholder="Article, video, or skill..."
+          placeholder="Article title, URL, or both..."
           @keydown.enter="handleAddItem"
           @keydown.escape="cancelAdd"
         />
@@ -123,9 +158,9 @@ async function handleDelete(id: number) {
               v-for="item in store.backlogItems"
               :key="item.id"
               :item="item"
-              :show-toggle="true"
-              @toggle="handleToggle"
+              @consume="handleConsume"
               @toggle-active="handleToggleActive"
+              @review="handleReview"
               @delete="handleDelete"
             />
           </div>
@@ -140,14 +175,22 @@ async function handleDelete(id: number) {
               v-for="item in store.completedItems"
               :key="item.id"
               :item="item"
-              :show-toggle="false"
-              @toggle="handleToggle"
+              @consume="handleConsume"
               @toggle-active="handleToggleActive"
+              @review="handleReview"
               @delete="handleDelete"
             />
           </div>
         </div>
       </template>
     </div>
+
+    <LearningCompleteModal
+      :is-open="modalOpen"
+      :item="modalItem"
+      :mode="modalMode"
+      @submit="handleModalSubmit"
+      @close="handleModalClose"
+    />
   </div>
 </template>

--- a/web/src/components/ReadingItemRow.spec.ts
+++ b/web/src/components/ReadingItemRow.spec.ts
@@ -1,0 +1,110 @@
+import { mount } from '@vue/test-utils'
+import ReadingItemRow from './ReadingItemRow.vue'
+import type { ReadWatchItem } from '@/types'
+
+const createMockItem = (overrides: Partial<ReadWatchItem> = {}): ReadWatchItem => ({
+  id: 1,
+  title: 'Test article',
+  url: '',
+  type: 'Read',
+  isDone: false,
+  isActive: true,
+  worthSharing: null,
+  notes: null,
+  weekConsumed: null,
+  date: '2026-04-08',
+  ...overrides,
+})
+
+function mountRow(item: ReadWatchItem, showActions = true) {
+  return mount(ReadingItemRow, {
+    props: { item, showActions },
+  })
+}
+
+describe('ReadingItemRow', () => {
+  it('ReadingItemRow_ShowsEmojiForType_WhenRead', () => {
+    const wrapper = mountRow(createMockItem({ type: 'Read' }))
+
+    expect(wrapper.get('[data-testid="type-emoji"]').text()).toContain('📔')
+  })
+
+  it('ReadingItemRow_ShowsEmojiForType_WhenWatch', () => {
+    const wrapper = mountRow(createMockItem({ type: 'Watch' }))
+
+    expect(wrapper.get('[data-testid="type-emoji"]').text()).toContain('📺')
+  })
+
+  it('ReadingItemRow_ShowsEmojiForType_WhenLearn', () => {
+    const wrapper = mountRow(createMockItem({ type: 'Learn' }))
+
+    expect(wrapper.get('[data-testid="type-emoji"]').text()).toContain('🎓')
+  })
+
+  it('ReadingItemRow_RendersAnchorLink_WhenUrlPresent', () => {
+    const wrapper = mountRow(createMockItem({
+      title: 'Linked article',
+      url: 'https://example.com',
+    }))
+
+    const link = wrapper.get('[data-testid="item-link"]')
+    expect(link.element.tagName).toBe('A')
+    expect(link.attributes('href')).toBe('https://example.com')
+    expect(link.attributes('target')).toBe('_blank')
+    expect(link.text()).toContain('Linked article')
+  })
+
+  it('ReadingItemRow_RendersPlainText_WhenNoUrl', () => {
+    const wrapper = mountRow(createMockItem({ url: '' }))
+
+    expect(wrapper.find('[data-testid="item-link"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="item-text"]').text()).toContain('Test article')
+  })
+
+  it('ReadingItemRow_EmitsConsume_WhenCheckClicked', async () => {
+    const wrapper = mountRow(createMockItem())
+
+    await wrapper.get('[data-testid="consume-btn"]').trigger('click')
+
+    expect(wrapper.emitted('consume')).toBeTruthy()
+    expect(wrapper.emitted('consume')![0]).toEqual([1])
+  })
+
+  it('ReadingItemRow_EmitsToggleActive_WhenBacklogClicked', async () => {
+    const wrapper = mountRow(createMockItem())
+
+    await wrapper.get('[data-testid="toggle-active-btn"]').trigger('click')
+
+    expect(wrapper.emitted('toggle-active')).toBeTruthy()
+    expect(wrapper.emitted('toggle-active')![0]).toEqual([1])
+  })
+
+  it('ReadingItemRow_ShowsBacklogLabel_WhenActive', () => {
+    const wrapper = mountRow(createMockItem({ isActive: true }))
+
+    expect(wrapper.get('[data-testid="toggle-active-btn"]').text()).toContain('backlog')
+  })
+
+  it('ReadingItemRow_ShowsActivateLabel_WhenBacklogged', () => {
+    const wrapper = mountRow(createMockItem({ isActive: false }))
+
+    expect(wrapper.get('[data-testid="toggle-active-btn"]').text()).toContain('activate')
+  })
+
+  it('ReadingItemRow_ShowsReviewButton_WhenDone', () => {
+    const wrapper = mountRow(createMockItem({ isDone: true }))
+
+    expect(wrapper.find('[data-testid="review-btn"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="consume-btn"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="toggle-active-btn"]').exists()).toBe(false)
+  })
+
+  it('ReadingItemRow_EmitsReview_WhenReviewClicked', async () => {
+    const wrapper = mountRow(createMockItem({ isDone: true }))
+
+    await wrapper.get('[data-testid="review-btn"]').trigger('click')
+
+    expect(wrapper.emitted('review')).toBeTruthy()
+    expect(wrapper.emitted('review')![0]).toEqual([1])
+  })
+})

--- a/web/src/components/ReadingItemRow.vue
+++ b/web/src/components/ReadingItemRow.vue
@@ -1,44 +1,45 @@
 <script setup lang="ts">
 import type { ReadWatchItem } from '@/types'
 
-const { item, showToggle = false } = defineProps<{
+const { item, showActions = true } = defineProps<{
   item: ReadWatchItem
-  showToggle?: boolean
+  showActions?: boolean
 }>()
 
 const emit = defineEmits<{
-  toggle: [id: number]
+  consume: [id: number]
   'toggle-active': [id: number]
+  review: [id: number]
   delete: [id: number]
 }>()
 
-const TYPE_STYLES = {
-  read: 'text-red-400',
-  watch: 'text-blue-400',
-  learn: 'text-green-400',
-} as const
-
-const TYPE_LABELS = {
-  read: 'READ',
-  watch: 'WATCH',
-  learn: 'LEARN',
+const TYPE_EMOJI = {
+  Read: '📔',
+  Watch: '📺',
+  Learn: '🎓',
 } as const
 </script>
 
 <template>
   <div class="flex items-start gap-2 text-sm group py-1">
-    <button class="flex-shrink-0" @click="emit('toggle', item.id)">
-      <span v-if="item.isDone" class="text-primary">[x]</span>
-      <span v-else class="text-muted-foreground">[ ]</span>
+    <button
+      v-if="!item.isDone && showActions"
+      data-testid="consume-btn"
+      class="flex-shrink-0"
+      @click="emit('consume', item.id)"
+    >
+      <span class="text-muted-foreground">[ ]</span>
     </button>
-    <span :class="['text-xs font-medium shrink-0', TYPE_STYLES[item.type || 'read']]">
-      {{ TYPE_LABELS[item.type || 'read'] }}
+    <span v-if="item.isDone" class="flex-shrink-0 text-primary">[x]</span>
+    <span data-testid="type-emoji" class="shrink-0">
+      {{ TYPE_EMOJI[item.type] || '📔' }}
     </span>
     <a
       v-if="item.url"
       :href="item.url"
       target="_blank"
       rel="noopener"
+      data-testid="item-link"
       :class="[
         'flex-1 break-words hover:underline',
         item.isDone ? 'line-through text-muted-foreground' : 'text-foreground',
@@ -48,6 +49,7 @@ const TYPE_LABELS = {
     </a>
     <span
       v-else
+      data-testid="item-text"
       :class="[
         'flex-1 break-words',
         item.isDone ? 'line-through text-muted-foreground' : 'text-foreground',
@@ -56,13 +58,24 @@ const TYPE_LABELS = {
       {{ item.title }}
     </span>
     <button
-      v-if="showToggle && !item.isDone"
+      v-if="item.isDone && showActions"
+      data-testid="review-btn"
+      class="text-muted-foreground hover:text-primary text-xs shrink-0"
+      @click="emit('review', item.id)"
+    >
+      [review]
+    </button>
+    <button
+      v-if="!item.isDone && showActions"
+      data-testid="toggle-active-btn"
       class="text-muted-foreground hover:text-primary text-xs shrink-0"
       @click="emit('toggle-active', item.id)"
     >
-      [{{ item.isActive ? '-' : '+' }}]
+      [{{ item.isActive ? 'backlog' : 'activate' }}]
     </button>
     <button
+      v-if="showActions"
+      data-testid="delete-btn"
       class="opacity-0 group-hover:opacity-100 text-destructive text-xs shrink-0"
       @click="emit('delete', item.id)"
     >

--- a/web/src/stores/readWatch.ts
+++ b/web/src/stores/readWatch.ts
@@ -10,25 +10,31 @@ export const useReadWatchStore = defineStore('readWatch', () => {
   const backlogItems = computed(() => items.value.filter((i) => !i.isActive && !i.isDone))
   const completedItems = computed(() => items.value.filter((i) => i.isDone))
 
-  async function fetch(date?: string) {
-    const params = date ? { date } : {}
+  async function fetch(params?: { date?: string; weekOf?: string }) {
     items.value = await client.get('/api/read-watch', { params }) as any
   }
 
-  async function create(title: string, url: string, type: 'read' | 'watch' | 'learn' = 'read') {
-    const item: ReadWatchItem = await client.post('/api/read-watch', { title, url, type }) as any
-    item.isActive = activeItems.value.length < 5
+  async function create(text: string, type: 'Read' | 'Watch' | 'Learn' = 'Read') {
+    const item: ReadWatchItem = await client.post('/api/read-watch', { text, type }) as any
     items.value.push(item)
   }
 
-  async function update(id: number, data: { title?: string; url?: string; type?: 'read' | 'watch' | 'learn'; isDone?: boolean }) {
+  async function update(id: number, data: { title?: string; url?: string; isActive?: boolean }) {
     const updated: ReadWatchItem = await client.put(`/api/read-watch/${id}`, data) as any
     const idx = items.value.findIndex((i) => i.id === id)
-    if (idx !== -1) {
-      updated.isActive = items.value[idx]!.isActive
-      if (data.isDone) updated.isActive = false
-      items.value[idx] = updated
-    }
+    if (idx !== -1) items.value[idx] = updated
+  }
+
+  async function toggleActive(id: number) {
+    const item = items.value.find((i) => i.id === id)
+    if (!item) return
+    await update(id, { isActive: !item.isActive })
+  }
+
+  async function consume(id: number, data: { worthSharing: boolean; notes: string; weekOf: string }) {
+    const updated: ReadWatchItem = await client.put(`/api/read-watch/${id}/consume`, data) as any
+    const idx = items.value.findIndex((i) => i.id === id)
+    if (idx !== -1) items.value[idx] = updated
   }
 
   async function remove(id: number) {
@@ -36,15 +42,5 @@ export const useReadWatchStore = defineStore('readWatch', () => {
     items.value = items.value.filter((i) => i.id !== id)
   }
 
-  function toggleActive(id: number) {
-    const item = items.value.find((i) => i.id === id)
-    if (!item) return
-    if (item.isActive) {
-      item.isActive = false
-    } else if (activeItems.value.length < 5) {
-      item.isActive = true
-    }
-  }
-
-  return { items, activeItems, backlogItems, completedItems, fetch, create, update, remove, toggleActive }
+  return { items, activeItems, backlogItems, completedItems, fetch, create, update, toggleActive, consume, remove }
 })

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -13,8 +13,11 @@ export interface ReadWatchItem {
   id: number
   title: string
   url: string
-  type: 'read' | 'watch' | 'learn'
+  type: 'Read' | 'Watch' | 'Learn'
   isDone: boolean
-  isActive?: boolean
+  isActive: boolean
+  worthSharing: boolean | null
+  notes: string | null
+  weekConsumed: string | null
   date: string
 }

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { onMounted, ref, computed } from 'vue'
+import { onMounted, ref, computed, watch } from 'vue'
 import { useWorkItemsStore } from '@/stores/workItems'
 import { useReadWatchStore } from '@/stores/readWatch'
 import { useDailyTasksStore } from '@/stores/dailyTasks'
 import { useScratchPadStore } from '@/stores/scratchPad'
-import { DAYS } from '@/utils/week'
+import { DAYS, getToday, getWeekStart } from '@/utils/week'
 import type { CommandType } from '@/types'
 import BigThing from '@/components/BigThing.vue'
 import DailyTasks from '@/components/DailyTasks.vue'
@@ -61,9 +61,19 @@ function formatTime(date: Date): string {
   })
 }
 
+function fetchReadWatch() {
+  if (view.value === 'weekly') {
+    readWatch.fetch({ weekOf: getWeekStart() })
+  } else {
+    readWatch.fetch({ date: getToday() })
+  }
+}
+
+watch(view, () => fetchReadWatch())
+
 onMounted(() => {
   workItems.fetch()
-  readWatch.fetch()
+  fetchReadWatch()
   dailyTasks.fetch()
   scratchPad.fetch()
 })


### PR DESCRIPTION
## Summary

- **API**: `ReadWatchType` enum (Read/Watch/Learn), new fields `IsActive`, `WorthSharing`, `Notes`, `WeekConsumed` on `ReadWatchItems` with EF migration; POST parses free-text for embedded URLs; GET supports `?date=` (daily: active+not-done) and `?weekOf=` (weekly: all not-done + consumed that week); new `PUT /{id}/consume` endpoint records findings and marks done
- **Frontend**: emoji type badges (📔📺🎓), backlog/activate toggle persisted to API, `LearningCompleteModal` shared between consume and review modes with required worth-sharing radio and notes textarea; daily/weekly views fetch with appropriate query params on view switch
- **Tests**: 11 API integration tests + 19 frontend component tests (ReadingItemRow + LearningCompleteModal)

## Test plan

- [ ] Create a learning item with a URL embedded in the text — confirm title and link are parsed correctly
- [ ] Create a plain-text item — confirm no anchor tag rendered
- [ ] Toggle an item to backlog — confirm it disappears from daily view, appears in weekly backlog section
- [ ] Toggle it back to active — confirm it returns to active queue
- [ ] Click the check on an active item — confirm modal opens, submit is disabled until both radio and notes filled
- [ ] Complete the modal — confirm item moves to completed, weekly view shows it under consumed
- [ ] Click `[review]` on a completed item — confirm modal opens pre-filled, changes can be saved
- [ ] Verify emoji badges match type (📔 Read, 📺 Watch, 🎓 Learn)
- [ ] Switch between daily/weekly views — confirm read-watch list re-fetches with correct params

🤖 Generated with [Claude Code](https://claude.com/claude-code)