### PR TITLE
Add PR feedback triage command documentation

### DIFF
--- a/.claude/commands/pr-feedback.md
+++ b/.claude/commands/pr-feedback.md
@@ -1,0 +1,45 @@
+# .claude/commands/pr-feedback.md
+
+
+
+Determine the PR number to review:
+
+- If a PR number was provided via arguments: $ARGUMENTS — use that directly
+
+- Otherwise, run `gh pr view --json number --jq '.number'` to get the current branch's open PR
+
+
+
+Then use `gh` CLI to:
+
+1. Fetch all formal PR reviews on that PR
+
+2. Filter to the most recent Copilot review
+
+3. Fetch all line-level and summary review comments
+
+
+
+Triage each piece of feedback into:
+
+- **Address Now** – correctness, security, bugs, breaking changes
+
+- **Backlog** – valid but non-blocking improvements  
+
+- **Ignore** – stylistic, overly opinionated, out of scope for this PR
+
+
+
+Flag these with extra urgency:
+
+- Security issues (auth, secrets, input validation)
+
+- Azure SDK misuse or anti-patterns
+
+- EF Core / database performance concerns
+
+- TypeScript `any` usage or missing types in Vue components
+
+
+
+Group by category, summarize "Address Now" items first, and ask which to tackle first.

--- a/daily-work.slnx
+++ b/daily-work.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/.claude/commands/">
+    <File Path=".claude/commands/pr-feedback.md" />
+  </Folder>
   <Folder Name="/.claude/rules/">
     <File Path=".claude/rules/api.md" />
     <File Path=".claude/rules/commits.md" />


### PR DESCRIPTION
Add PR feedback triage command documentation

Added .claude/commands/pr-feedback.md detailing a process for reviewing and triaging PR feedback using the GitHub CLI, including steps for identifying urgent issues. Registered the new command file in daily-work.slnx under a new /.claude/commands/ folder.

#### PR Classification
Documentation update to add a new command guide for PR feedback review.

#### PR Summary
This PR introduces documentation for a new command that standardizes the process of reviewing and triaging pull request feedback using the GitHub CLI. The solution file is updated to include this documentation.
- .claude/commands/pr-feedback.md: Added detailed instructions for fetching, categorizing, and summarizing PR feedback.
- daily-work.slnx: Registered the new command documentation file in the solution structure.
