### PR TITLE
feat(api,web): add Friday standup prompt and Experiment learning queue type

### DIFF
--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -114,9 +114,26 @@ internal static class StandupEndpoints
                 ? StandupPrompts.GetSystemPrompt(DayOfWeek.Monday)
                 : StandupPrompts.GetSystemPrompt(dayOfWeek);
 
+            // On Fridays, fetch consumed learning queue items for the week
+            string? learningQueueJson = null;
+            if (dayOfWeek == DayOfWeek.Friday && !useWeeklyPrompt)
+            {
+                var weekStart = DateOnly.Parse(weekOf, CultureInfo.InvariantCulture);
+                var consumedItems = await db.ReadWatchItems
+                    .AsNoTracking()
+                    .Where(r => r.IsDone && r.WeekConsumed == weekStart
+                        && (r.Type == Enums.ReadWatchType.Experiment || r.WorthSharing == true))
+                    .OrderByDescending(r => r.Type == Enums.ReadWatchType.Experiment)
+                    .ThenByDescending(r => r.WorthSharing)
+                    .ToListAsync();
+
+                if (consumedItems.Count > 0)
+                    learningQueueJson = JsonSerializer.Serialize(consumedItems, JsonOptions);
+            }
+
             var chatHistory = new ChatHistory();
             chatHistory.AddSystemMessage(systemPrompt);
-            chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(workItemsJson, today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
+            chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(workItemsJson, today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), learningQueueJson));
 
             var response = await chatService.GetChatMessageContentAsync(chatHistory);
 

--- a/api/src/Enums/ReadWatchType.cs
+++ b/api/src/Enums/ReadWatchType.cs
@@ -5,4 +5,5 @@ internal enum ReadWatchType
     Read = 1,
     Watch = 2,
     Learn = 3,
+    Experiment = 4,
 }

--- a/api/src/Prompts/StandupPrompts.cs
+++ b/api/src/Prompts/StandupPrompts.cs
@@ -9,8 +9,13 @@ internal static class StandupPrompts
         _ => GetMidWeekPrompt(),
     };
 
-    internal static string BuildUserMessage(string workItemsJson, string today) =>
-        $"Today's date: {today}\n\nWork items:\n{workItemsJson}";
+    internal static string BuildUserMessage(string workItemsJson, string today, string? learningQueueJson = null)
+    {
+        var message = $"Today's date: {today}\n\nWork items:\n{workItemsJson}";
+        if (learningQueueJson is not null)
+            message += $"\n\nLearning queue items consumed this week:\n{learningQueueJson}";
+        return message;
+    }
 
     private static string GetMidWeekPrompt() => """
         You are a standup response writer. Answer exactly 3 standup questions using the provided work items.
@@ -58,5 +63,70 @@ internal static class StandupPrompts
 
     private static string GetMondayPrompt() => "Monday prompt — TODO";
 
-    private static string GetFridayPrompt() => "Friday prompt — TODO";
+    private static string GetFridayPrompt() => """
+        You are a standup response writer. Answer exactly 4 standup questions using the provided work items and learning queue data.
+        Do NOT add summaries, tables, counts, or extra sections beyond the 4 answers.
+
+        Work item fields:
+        - category: "BigThing" = weekly goal, "SmallThing" = daily task
+        - isDone: completion status
+        - date: scheduled day
+        - sortOrder: items are pre-sorted; the FIRST SmallThing for a given date is the "One Thing" / "big thing of the day"
+
+        Learning queue item fields (provided separately, may be empty):
+        - title: name of the resource
+        - url: link to the resource
+        - type: "Experiment" = hands-on experiment, "Read"/"Watch"/"Learn" = consumed content
+        - worthSharing: true if marked as worth sharing to the team
+        - notes: the user's findings/takeaways
+
+        Output exactly this structure (use ### for each question heading):
+
+        ### Did you complete your One Thing yesterday?
+        Kinda — got **Examine PDL payload** across the line.
+
+        Smaller stuff: knocked out **Weekly Kickoff Prep**, carried **Graham CRM+ discussion** and **Submit AI Qualifying Race**.
+
+        The first line addresses ONLY yesterday's big thing of the day (the first SmallThing by sortOrder for yesterday's date). Lead with an opener that varies based on whether THAT specific item was done:
+        - DONE: enthusiastic — pick one: "Hell yea!", "YESSIR!", "You know it!", "YES!", "Crushed it.", "Nailed it.", "Lock it in.", "Big day yesterday.", "Clean sweep.", "All green, baby."
+        - NOT DONE: self-deprecating — pick one: "NOPE.", "That's funny.", "Not even close.", "What was I thinking?", "Lol no.", "About that...", "Let's not talk about it.", "Swing and a miss.", "Bold of you to ask.", "Yeah... no."
+        - PARTIAL CREDIT (e.g. in progress): hedging — pick one: "Kinda.", "Sort of.", "Getting there.", "Halfway hero.", "Progress, not perfection."
+        Pick a different one each time — never repeat the same opener twice in a row.
+
+        Then a BLANK LINE, then a "Smaller stuff:" line summarizing yesterday's other SmallThings (done/carried).
+
+        ### What's the One Thing you will complete today in service of the weekly goal?
+        **Start Insights work — examine PDL payload/data store**, feeding the weekly goal of **Data Products support**.
+
+        Also on deck: Submit AI Qualifying Race, Align on CRM+ OKRs, Sync with Ali.
+
+        The first line is ONLY today's big thing of the day (first SmallThing by sortOrder for today) tied back to the weekly BigThing.
+        Then a BLANK LINE, then "Also on deck:" listing today's remaining SmallThings.
+
+        ### Do you have any upcoming PTO or unavailability the team should know about?
+        No
+
+        ### What's one experiment, improvement, or lesson from this week that helped you (or could help the team)?
+        This week I tried **[title]** — [revised notes as a concise value prop]. Worth checking out: [url]
+
+        Bonus points for a Loom video showing it!
+
+        For this 4th question, use the learning queue data provided:
+        1. PRIORITY: "Experiment" type items always take precedence — these are hands-on experiments the user ran.
+        2. FALLBACK: If no experiments, use items where worthSharing = true.
+        3. If neither exists, simply return "Nothing noted this week."
+
+        When using a learning queue item:
+        - Bold the item title.
+        - Revise the user's notes for clarity — tighten the language, highlight the value prop, make it useful for teammates who haven't seen the resource.
+        - Include the URL as a link if available.
+        - Keep it to 2-3 sentences max.
+
+        Style rules:
+        - Write in first person. This gets pasted into Geekbot.
+        - Bold task names and the weekly goal with **markdown bold**.
+        - Keep answers short — lead with the key item, not a full sentence. Fragments are fine.
+        - Do NOT repeat the questions word-for-word if you can keep it clear without them.
+        - Under 180 words total.
+        """;
 }

--- a/api/tests/StandupPromptTests.cs
+++ b/api/tests/StandupPromptTests.cs
@@ -43,7 +43,11 @@ public class StandupPromptTests
     {
         var prompt = StandupPrompts.GetSystemPrompt(DayOfWeek.Friday);
 
-        Assert.Contains("Friday", prompt);
+        Assert.Contains("Did you complete your One Thing yesterday", prompt);
+        Assert.Contains("What's the One Thing you will complete today", prompt);
+        Assert.Contains("experiment, improvement, or lesson", prompt);
+        Assert.Contains("Experiment", prompt);
+        Assert.Contains("worthSharing", prompt);
     }
 
     [Fact]
@@ -65,5 +69,20 @@ public class StandupPromptTests
 
         Assert.Contains("Today's date: 2026-04-07", message);
         Assert.Contains(json, message);
+        Assert.DoesNotContain("Learning queue", message);
+    }
+
+    [Fact]
+    public void BuildUserMessage_IncludesLearningQueue_WhenProvided()
+    {
+        var workJson = """[{"id":1,"title":"Test"}]""";
+        var learningJson = """[{"title":"Cool experiment","type":"Experiment"}]""";
+
+        var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-10", learningJson);
+
+        Assert.Contains("Today's date: 2026-04-10", message);
+        Assert.Contains(workJson, message);
+        Assert.Contains("Learning queue items consumed this week", message);
+        Assert.Contains(learningJson, message);
     }
 }

--- a/web/src/components/ReadWatchList.vue
+++ b/web/src/components/ReadWatchList.vue
@@ -13,7 +13,7 @@ const { defaultShowAll = false } = defineProps<{
 const store = useReadWatchStore()
 
 const newText = ref('')
-const newType = ref<'Read' | 'Watch' | 'Learn'>('Read')
+const newType = ref<'Read' | 'Watch' | 'Learn' | 'Experiment'>('Read')
 const isAdding = ref(false)
 const showAll = ref(defaultShowAll)
 const inputRef = ref<HTMLInputElement | null>(null)
@@ -129,6 +129,7 @@ async function handleDelete(id: number) {
           <option value="Read">READ</option>
           <option value="Watch">WATCH</option>
           <option value="Learn">LEARN</option>
+          <option value="Experiment">EXPERIMENT</option>
         </select>
         <input
           ref="inputRef"

--- a/web/src/components/ReadingItemRow.spec.ts
+++ b/web/src/components/ReadingItemRow.spec.ts
@@ -41,6 +41,12 @@ describe('ReadingItemRow', () => {
     expect(wrapper.get('[data-testid="type-emoji"]').text()).toContain('🎓')
   })
 
+  it('ReadingItemRow_ShowsEmojiForType_WhenExperiment', () => {
+    const wrapper = mountRow(createMockItem({ type: 'Experiment' }))
+
+    expect(wrapper.get('[data-testid="type-emoji"]').text()).toContain('🧪')
+  })
+
   it('ReadingItemRow_RendersAnchorLink_WhenUrlPresent', () => {
     const wrapper = mountRow(createMockItem({
       title: 'Linked article',

--- a/web/src/components/ReadingItemRow.vue
+++ b/web/src/components/ReadingItemRow.vue
@@ -17,6 +17,7 @@ const TYPE_EMOJI = {
   Read: '📔',
   Watch: '📺',
   Learn: '🎓',
+  Experiment: '🧪',
 } as const
 </script>
 

--- a/web/src/stores/readWatch.ts
+++ b/web/src/stores/readWatch.ts
@@ -14,7 +14,7 @@ export const useReadWatchStore = defineStore('readWatch', () => {
     items.value = await client.get('/api/read-watch', { params }) as any
   }
 
-  async function create(text: string, type: 'Read' | 'Watch' | 'Learn' = 'Read') {
+  async function create(text: string, type: ReadWatchItem['type'] = 'Read') {
     const item: ReadWatchItem = await client.post('/api/read-watch', { text, type }) as any
     items.value.push(item)
   }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -14,7 +14,7 @@ export interface ReadWatchItem {
   id: number
   title: string
   url: string
-  type: 'Read' | 'Watch' | 'Learn'
+  type: 'Read' | 'Watch' | 'Learn' | 'Experiment'
   isDone: boolean
   isActive: boolean
   worthSharing: boolean | null


### PR DESCRIPTION
## Summary
- Implement Friday standup prompt with 4 questions (mid-week 3 + "What's one experiment, improvement, or lesson from this week?")
- Add `Experiment` type (`🧪`) to the learning queue (`ReadWatchType` enum, frontend type selector, emoji mapping)
- On Fridays, the generate endpoint fetches consumed learning queue items for the week — experiments take precedence over worth-sharing items — and passes them to the AI for note revision

## Test plan
- [ ] `dotnet test` in `api/tests/` — StandupPromptTests pass (Friday prompt assertions + BuildUserMessage with learning queue)
- [ ] `npx vitest run` in `web/` — ReadingItemRow spec passes including new Experiment emoji test
- [ ] Manual: add an Experiment item via learning queue dropdown, consume it, run `/standup` on a Friday

🤖 Generated with [Claude Code](https://claude.com/claude-code)