### PR TITLE
feat(api,web): add read-only past-week view with AI weekly summary

### DIFF
--- a/api/src/Data/AppDbContext.cs
+++ b/api/src/Data/AppDbContext.cs
@@ -31,7 +31,8 @@ internal class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(
             e.ToTable("UpdateComms");
             e.HasDiscriminator(c => c.CommType)
              .HasValue<DailyStandupComm>(CommType.DailyStandup)
-             .HasValue<WeeklyUpdateComm>(CommType.WeeklyUpdate);
+             .HasValue<WeeklyUpdateComm>(CommType.WeeklyUpdate)
+             .HasValue<WeeklySummaryComm>(CommType.WeeklySummary);
             e.HasIndex(c => new { c.Date, c.CommType }).IsUnique();
         });
 

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -62,6 +62,55 @@ internal static class StandupEndpoints
             return Results.Ok(new { entry.Markdown, Date = entry.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) });
         });
 
+        group.MapPost("/generate-weekly-summary", async (
+            AppDbContext db,
+            IChatCompletionService? chatService,
+            string? weekOf) =>
+        {
+            if (chatService is null)
+                return Results.Problem("Azure OpenAI is not configured.", statusCode: 503);
+
+            if (weekOf is null)
+                return Results.BadRequest("weekOf query parameter is required.");
+
+            var weekStart = DateOnly.Parse(weekOf, CultureInfo.InvariantCulture);
+            var weekEnd = weekStart.AddDays(4);
+
+            var dailyComms = await db.UpdateComms
+                .AsNoTracking()
+                .Where(c => c.CommType == CommType.DailyStandup
+                    && c.Date >= weekStart
+                    && c.Date <= weekEnd)
+                .OrderBy(c => c.Date)
+                .Select(c => new { Date = c.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), c.Markdown })
+                .ToListAsync();
+
+            var dailyCommsJson = JsonSerializer.Serialize(dailyComms, JsonOptions);
+
+            var chatHistory = new ChatHistory();
+            chatHistory.AddSystemMessage(WeeklySummaryPrompts.GetSystemPrompt());
+            chatHistory.AddUserMessage(WeeklySummaryPrompts.BuildUserMessage(weekOf, dailyCommsJson));
+
+            var response = await chatService.GetChatMessageContentAsync(chatHistory);
+            var markdown = response.Content ?? string.Empty;
+
+            var existing = await db.UpdateComms.FirstOrDefaultAsync(
+                c => c.Date == weekStart && c.CommType == CommType.WeeklySummary);
+
+            if (existing is not null)
+            {
+                existing.Markdown = markdown;
+            }
+            else
+            {
+                db.UpdateComms.Add(new WeeklySummaryComm { Date = weekStart, Markdown = markdown });
+            }
+
+            await db.SaveChangesAsync();
+
+            return Results.Ok(new { markdown, weekOf });
+        });
+
         group.MapPost("/generate", async (
             AppDbContext db,
             IDateTimeProvider dateTime,
@@ -143,8 +192,12 @@ internal static class StandupEndpoints
         return group;
     }
 
-    private static CommType ResolveCommType(string? commandType) =>
-        string.Equals(commandType, "weekly", StringComparison.OrdinalIgnoreCase)
-            ? CommType.WeeklyUpdate
-            : CommType.DailyStandup;
+    private static CommType ResolveCommType(string? commandType)
+    {
+        if (string.Equals(commandType, "weekly", StringComparison.OrdinalIgnoreCase))
+            return CommType.WeeklyUpdate;
+        if (string.Equals(commandType, "weekly-summary", StringComparison.OrdinalIgnoreCase))
+            return CommType.WeeklySummary;
+        return CommType.DailyStandup;
+    }
 }

--- a/api/src/Entities/UpdateComm.cs
+++ b/api/src/Entities/UpdateComm.cs
@@ -20,3 +20,8 @@ internal class WeeklyUpdateComm : UpdateComm
 {
     public WeeklyUpdateComm() { CommType = CommType.WeeklyUpdate; }
 }
+
+internal class WeeklySummaryComm : UpdateComm
+{
+    public WeeklySummaryComm() { CommType = CommType.WeeklySummary; }
+}

--- a/api/src/Enums/CommType.cs
+++ b/api/src/Enums/CommType.cs
@@ -4,4 +4,5 @@ internal enum CommType
 {
     DailyStandup = 1,
     WeeklyUpdate = 2,
+    WeeklySummary = 3,
 }

--- a/api/src/Prompts/WeeklySummaryPrompts.cs
+++ b/api/src/Prompts/WeeklySummaryPrompts.cs
@@ -1,0 +1,29 @@
+namespace DailyWork.Api.Prompts;
+
+internal static class WeeklySummaryPrompts
+{
+    internal static string GetSystemPrompt() => """
+        You are writing a concise, optimistic recap of the user's work week.
+        You will be given the user's saved daily standup comms for the week (Monday through Friday).
+        These already summarize what was done each day — your job is to synthesize them into ONE short weekly recap.
+
+        Tone:
+        - Straightforward, leaning optimistic. Celebrate wins without being saccharine.
+        - First person. Written as if the user is telling a teammate how the week went.
+        - No hype, no empty filler, no hedging.
+
+        Structure (markdown):
+        - A one-line opener that captures the vibe of the week.
+        - A short "Highlights" bullet list (3-5 bullets) of the most meaningful wins or completed work.
+        - A one-line close looking forward — light, forward-facing, optional.
+
+        Rules:
+        - Under 150 words total.
+        - Bold key task/project names with **markdown bold**.
+        - Do NOT list every item. Pick what mattered.
+        - If the daily comms are sparse or empty, say so briefly and stay positive.
+        """;
+
+    internal static string BuildUserMessage(string weekOf, string dailyCommsJson) =>
+        $"Week of: {weekOf}\n\nDaily standup comms for the week:\n{dailyCommsJson}";
+}

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -106,6 +106,45 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>
     }
 
     [Fact]
+    public async Task GenerateWeeklySummary_PersistsAndReturnsMarkdown_WhenDailyCommsExist()
+    {
+        // Arrange
+        _factory.ChatCompletionService.ResponseContent = "### Weekly recap\nStrong week overall.";
+
+        // Seed a daily standup comm inside the target week
+        var weekOf = "2020-03-09"; // Monday
+        await _client.PostAsJsonAsync("/api/standup", new
+        {
+            Markdown = "Tuesday highlights",
+            Date = "2020-03-10",
+        });
+
+        // Act
+        var response = await _client.PostAsync($"/api/standup/generate-weekly-summary?weekOf={weekOf}", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Contains("Strong week", result.GetProperty("markdown").GetString()!);
+
+        // Verify persisted — GET with commandType=weekly-summary
+        var getResponse = await _client.GetAsync($"/api/standup?date={weekOf}&commandType=weekly-summary");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var getResult = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        Assert.Contains("Strong week", getResult.GetProperty("markdown").GetString()!);
+    }
+
+    [Fact]
+    public async Task GenerateWeeklySummary_Returns400_WhenWeekOfMissing()
+    {
+        // Act
+        var response = await _client.PostAsync("/api/standup/generate-weekly-summary", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task SaveStandup_UpdatesEntry_WhenExisting()
     {
         // Arrange

--- a/web/src/components/PastWeekView.spec.ts
+++ b/web/src/components/PastWeekView.spec.ts
@@ -1,0 +1,170 @@
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+import type { Mock } from 'vitest'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import client from '@/api/client'
+import PastWeekView from './PastWeekView.vue'
+import type { WorkItem, ReadWatchItem } from '@/types'
+
+const mockGet = (client as any).get as Mock
+const mockPost = (client as any).post as Mock
+
+const WEEK = '2026-04-06'
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 1,
+    title: 'Task',
+    category: 'SmallThing',
+    isDone: false,
+    sortOrder: 1,
+    date: '2026-04-06',
+    weekOf: WEEK,
+    ...overrides,
+  }
+}
+
+function makeLearning(overrides: Partial<ReadWatchItem> = {}): ReadWatchItem {
+  return {
+    id: 1,
+    title: 'Learning',
+    url: '',
+    type: 'Read',
+    isDone: true,
+    isActive: false,
+    worthSharing: true,
+    notes: 'Great read',
+    weekConsumed: WEEK,
+    date: '2026-04-06',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+async function mountView() {
+  const wrapper = mount(PastWeekView, { props: { weekOf: WEEK } })
+  // flush the 3 sequential awaits in store.load
+  await nextTick()
+  await nextTick()
+  await nextTick()
+  await nextTick()
+  return wrapper
+}
+
+describe('PastWeekView', () => {
+  it('PastWeekView_RendersBigThing_WhenBigThingExists', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/work-items') {
+        return Promise.resolve([
+          makeWorkItem({ id: 10, title: 'Ship feature X', category: 'BigThing' }),
+          makeWorkItem({ id: 11, title: 'Write docs', category: 'SmallThing' }),
+        ])
+      }
+      if (url === '/api/read-watch') return Promise.resolve([])
+      if (url === '/api/standup') return Promise.reject(new Error('404'))
+      return Promise.resolve([])
+    })
+
+    const wrapper = await mountView()
+
+    expect(wrapper.get('[data-testid="past-big-thing"]').text()).toContain('Ship feature X')
+  })
+
+  it('PastWeekView_RendersCheckAndSquareMarkers_WhenTasksMixed', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/work-items') {
+        return Promise.resolve([
+          makeWorkItem({ id: 1, title: 'Done task', isDone: true, date: '2026-04-06', sortOrder: 1 }),
+          makeWorkItem({ id: 2, title: 'Not done task', isDone: false, date: '2026-04-06', sortOrder: 2 }),
+        ])
+      }
+      if (url === '/api/read-watch') return Promise.resolve([])
+      if (url === '/api/standup') return Promise.reject(new Error('404'))
+      return Promise.resolve([])
+    })
+
+    const wrapper = await mountView()
+
+    expect(wrapper.findAll('[data-testid="past-task-done"]')).toHaveLength(1)
+    expect(wrapper.findAll('[data-testid="past-task-pending"]')).toHaveLength(1)
+    // no interactive buttons on tasks
+    expect(wrapper.find('[data-testid="past-task"] button').exists()).toBe(false)
+  })
+
+  it('PastWeekView_RendersConsumedTable_WhenLearningsExist', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/work-items') return Promise.resolve([])
+      if (url === '/api/read-watch') {
+        return Promise.resolve([
+          makeLearning({ id: 1, title: 'Book A', url: 'https://example.com', worthSharing: true, notes: 'Loved it' }),
+          makeLearning({ id: 2, title: 'Book B', url: '', worthSharing: false, notes: 'Meh' }),
+        ])
+      }
+      if (url === '/api/standup') return Promise.reject(new Error('404'))
+      return Promise.resolve([])
+    })
+
+    const wrapper = await mountView()
+
+    const rows = wrapper.findAll('[data-testid="consumed-row"]')
+    expect(rows).toHaveLength(2)
+    const first = rows[0]!.text()
+    expect(first).toContain('Book A')
+    expect(first).toContain('yes')
+    expect(first).toContain('Loved it')
+    // title with url should be an anchor
+    expect(rows[0]!.find('a').attributes('href')).toBe('https://example.com')
+  })
+
+  it('PastWeekView_ShowsExistingSummary_WhenSummaryPresent', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/work-items') return Promise.resolve([])
+      if (url === '/api/read-watch') return Promise.resolve([])
+      if (url === '/api/standup') return Promise.resolve({ markdown: 'Stored weekly recap.' })
+      return Promise.resolve([])
+    })
+
+    const wrapper = await mountView()
+
+    expect(wrapper.find('[data-testid="summary-markdown"]').text()).toContain('Stored weekly recap.')
+    expect(wrapper.find('[data-testid="summary-prompt"]').exists()).toBe(false)
+  })
+
+  it('PastWeekView_GeneratesSummary_WhenGKeyPressed', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/work-items') return Promise.resolve([])
+      if (url === '/api/read-watch') return Promise.resolve([])
+      if (url === '/api/standup') return Promise.reject(new Error('404'))
+      return Promise.resolve([])
+    })
+    mockPost.mockResolvedValue({ markdown: 'Fresh weekly recap.' })
+
+    const wrapper = await mountView()
+
+    expect(wrapper.find('[data-testid="summary-prompt"]').exists()).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'G' }))
+    await nextTick()
+    await nextTick()
+    await nextTick()
+
+    expect(mockPost).toHaveBeenCalledWith(expect.stringContaining('/api/standup/generate-weekly-summary?weekOf=' + WEEK))
+    expect(wrapper.find('[data-testid="summary-markdown"]').text()).toContain('Fresh weekly recap.')
+
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/PastWeekView.vue
+++ b/web/src/components/PastWeekView.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, watch } from 'vue'
+import { usePastWeekStore } from '@/stores/pastWeek'
+import { DAYS, getDateForDayIndex, formatWeekRange } from '@/utils/week'
+import StatsPanel from '@/components/StatsPanel.vue'
+import type { WorkItem } from '@/types'
+
+const { weekOf } = defineProps<{ weekOf: string }>()
+
+const store = usePastWeekStore()
+
+const bigThing = computed<WorkItem | null>(
+  () => store.workItems.find((i) => i.category === 'BigThing') ?? null
+)
+
+function getTasksForDay(dayIndex: number): WorkItem[] {
+  const date = getDateForDayIndex(dayIndex, weekOf)
+  return store.workItems
+    .filter((t) => t.category === 'SmallThing' && t.date === date)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+}
+
+const consumedLearningsCount = computed(() => store.consumedLearnings.length)
+
+onMounted(() => store.load(weekOf))
+watch(() => weekOf, (w) => store.load(w))
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key !== 'G') return
+  const target = e.target as HTMLElement | null
+  if (target) {
+    const tag = target.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return
+  }
+  if (store.summaryMarkdown) return
+  if (store.isGenerating) return
+  e.preventDefault()
+  store.generateSummary()
+}
+
+onMounted(() => window.addEventListener('keydown', handleKeydown))
+onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
+</script>
+
+<template>
+  <div class="space-y-6 mt-6">
+    <div class="text-xs text-muted-foreground">
+      <span class="text-primary">$</span> cat ./archive/{{ formatWeekRange(weekOf) }}.log
+      <span class="ml-2 text-accent">[readonly]</span>
+    </div>
+
+    <!-- Big Thing (read-only) -->
+    <div class="border border-border p-4 bg-card" data-testid="past-big-thing">
+      <div class="flex items-center gap-2 text-muted-foreground text-sm mb-3">
+        <span class="text-primary">$</span>
+        <span>echo $WEEKLY_OBJECTIVE</span>
+      </div>
+      <div v-if="bigThing" class="text-accent text-lg">{{ bigThing.title }}</div>
+      <div v-else class="text-muted-foreground italic text-sm">&lt;no objective set&gt;</div>
+    </div>
+
+    <!-- Stats + Tasks grid -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div class="lg:col-span-2">
+        <div class="flex items-center gap-2 text-muted-foreground text-sm mb-3">
+          <span class="text-primary">$</span>
+          <span>ls -la /week/tasks/daily/ --readonly</span>
+        </div>
+        <div class="grid grid-cols-5 gap-2">
+          <div
+            v-for="(day, dayIndex) in DAYS"
+            :key="day"
+            class="border border-border/50 bg-muted/30 p-3 min-h-[140px]"
+          >
+            <div class="text-xs mb-2 text-muted-foreground">{{ day }}</div>
+            <div class="space-y-1">
+              <div
+                v-for="(task, taskIndex) in getTasksForDay(dayIndex)"
+                :key="task.id"
+                class="flex items-start gap-1 text-xs"
+                data-testid="past-task"
+              >
+                <span
+                  v-if="task.isDone"
+                  class="flex-shrink-0 text-primary"
+                  data-testid="past-task-done"
+                >&check;</span>
+                <span
+                  v-else
+                  class="flex-shrink-0 text-muted-foreground"
+                  data-testid="past-task-pending"
+                >&square;</span>
+                <span
+                  :class="[
+                    'flex-1 break-words',
+                    taskIndex === 0 ? 'uppercase text-accent font-bold' : 'text-foreground',
+                  ]"
+                >
+                  {{ task.title }}
+                </span>
+              </div>
+              <div
+                v-if="getTasksForDay(dayIndex).length === 0"
+                class="text-muted-foreground/50 text-xs"
+              >
+                &lt;empty&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <StatsPanel
+          :items="store.workItems"
+          :reading-queue-count="0"
+          :items-learned-count="consumedLearningsCount"
+        />
+      </div>
+    </div>
+
+    <!-- Consumed Learnings -->
+    <div class="border border-border p-4 bg-card">
+      <div class="flex items-center gap-2 text-muted-foreground text-sm mb-3">
+        <span class="text-primary">$</span>
+        <span>cat ./learnings/consumed.tsv</span>
+      </div>
+      <div v-if="store.consumedLearnings.length === 0" class="text-muted-foreground italic text-sm">
+        &lt;nothing consumed this week&gt;
+      </div>
+      <table v-else class="w-full text-sm" data-testid="consumed-table">
+        <thead>
+          <tr class="text-muted-foreground text-xs uppercase tracking-wider border-b border-border">
+            <th class="text-left py-2 pr-4">Title</th>
+            <th class="text-left py-2 pr-4">Shareable</th>
+            <th class="text-left py-2">Commentary</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="item in store.consumedLearnings"
+            :key="item.id"
+            class="border-b border-border/30"
+            data-testid="consumed-row"
+          >
+            <td class="py-2 pr-4 align-top">
+              <a
+                v-if="item.url"
+                :href="item.url"
+                target="_blank"
+                rel="noopener"
+                class="text-primary hover:underline"
+              >{{ item.title }}</a>
+              <span v-else class="text-foreground">{{ item.title }}</span>
+            </td>
+            <td class="py-2 pr-4 align-top text-foreground">
+              {{ item.worthSharing ? 'yes' : 'no' }}
+            </td>
+            <td class="py-2 align-top text-muted-foreground whitespace-pre-wrap">
+              {{ item.notes ?? '' }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Weekly summary -->
+    <div class="border border-border p-4 bg-card" data-testid="summary-section">
+      <div class="flex items-center gap-2 text-muted-foreground text-sm mb-3">
+        <span class="text-primary">$</span>
+        <span>ai --weekly-summary</span>
+      </div>
+      <div
+        v-if="store.summaryMarkdown"
+        class="text-sm text-foreground whitespace-pre-wrap"
+        data-testid="summary-markdown"
+      >{{ store.summaryMarkdown }}</div>
+      <div
+        v-else-if="store.isGenerating"
+        class="text-sm text-muted-foreground"
+        data-testid="summary-generating"
+      >
+        <span class="animate-pulse">generating weekly summary...</span>
+      </div>
+      <div
+        v-else
+        class="text-sm"
+        data-testid="summary-prompt"
+      >
+        <span class="inline-block bg-primary/20 border border-primary px-2 py-1 animate-pulse text-primary">
+          [G]enerate a weekly summary
+        </span>
+      </div>
+      <div v-if="store.error" class="text-destructive text-xs mt-2">{{ store.error }}</div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/StatsPanel.vue
+++ b/web/src/components/StatsPanel.vue
@@ -2,12 +2,24 @@
 import { computed } from 'vue'
 import { useDailyTasksStore } from '@/stores/dailyTasks'
 import { useReadWatchStore } from '@/stores/readWatch'
+import type { WorkItem } from '@/types'
+
+const {
+  items: itemsProp,
+  readingQueueCount,
+  itemsLearnedCount,
+} = defineProps<{
+  items?: WorkItem[]
+  readingQueueCount?: number
+  itemsLearnedCount?: number
+}>()
 
 const tasks = useDailyTasksStore()
 const readWatch = useReadWatchStore()
 
 const stats = computed(() => {
-  const smallItems = tasks.items.filter((t) => t.category === 'SmallThing')
+  const sourceItems = itemsProp ?? tasks.items
+  const smallItems = sourceItems.filter((t) => t.category === 'SmallThing')
 
   const minSortOrderByDate = new Map<string, number>()
   for (const item of smallItems) {
@@ -28,8 +40,8 @@ const stats = computed(() => {
     oneThingSummary: totalOneThings > 0 ? `${completedOneThings}/${totalOneThings}` : '—',
     smallerThingsSummary: totalSmallerThings > 0 ? `${completedSmallerThings}/${totalSmallerThings}` : '—',
     completionRate: totalOneThings > 0 ? `${Math.round((completedOneThings / totalOneThings) * 100)}%` : '—',
-    readingQueue: readWatch.activeItems.length,
-    itemsLearned: readWatch.completedItems.length,
+    readingQueue: readingQueueCount ?? readWatch.activeItems.length,
+    itemsLearned: itemsLearnedCount ?? readWatch.completedItems.length,
   }
 })
 </script>

--- a/web/src/stores/pastWeek.ts
+++ b/web/src/stores/pastWeek.ts
@@ -1,0 +1,67 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import client from '@/api/client'
+import type { WorkItem, ReadWatchItem } from '@/types'
+
+export const usePastWeekStore = defineStore('pastWeek', () => {
+  const weekOf = ref<string | null>(null)
+  const workItems = ref<WorkItem[]>([])
+  const consumedLearnings = ref<ReadWatchItem[]>([])
+  const summaryMarkdown = ref<string | null>(null)
+  const isLoading = ref(false)
+  const isGenerating = ref(false)
+  const error = ref<string | null>(null)
+
+  async function load(week: string) {
+    weekOf.value = week
+    isLoading.value = true
+    error.value = null
+    summaryMarkdown.value = null
+    try {
+      workItems.value = await client.get('/api/work-items', { params: { weekOf: week } }) as any
+      const rw = await client.get('/api/read-watch', { params: { weekOf: week } }) as any
+      consumedLearnings.value = (rw as ReadWatchItem[]).filter((i) => i.isDone && i.weekConsumed === week)
+
+      try {
+        const existing = await client.get('/api/standup', {
+          params: { date: week, commandType: 'weekly-summary' },
+        }) as any
+        summaryMarkdown.value = existing?.markdown ?? null
+      } catch {
+        summaryMarkdown.value = null
+      }
+    } catch (e: any) {
+      error.value = e?.message ?? 'Failed to load past week'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function generateSummary() {
+    if (!weekOf.value || isGenerating.value) return
+    isGenerating.value = true
+    error.value = null
+    try {
+      const result = await client.post(
+        `/api/standup/generate-weekly-summary?weekOf=${weekOf.value}`
+      ) as any
+      summaryMarkdown.value = result?.markdown ?? ''
+    } catch (e: any) {
+      error.value = e?.message ?? 'Failed to generate weekly summary'
+    } finally {
+      isGenerating.value = false
+    }
+  }
+
+  return {
+    weekOf,
+    workItems,
+    consumedLearnings,
+    summaryMarkdown,
+    isLoading,
+    isGenerating,
+    error,
+    load,
+    generateSummary,
+  }
+})

--- a/web/src/utils/week.spec.ts
+++ b/web/src/utils/week.spec.ts
@@ -1,4 +1,4 @@
-import { DAYS, getToday, getWeekStart, getCurrentDayIndex, getDateForDayIndex } from './week'
+import { DAYS, getToday, getWeekStart, getCurrentDayIndex, getDateForDayIndex, getRecentWeekStarts, formatWeekRange } from './week'
 
 describe('week utils', () => {
   describe('DAYS', () => {
@@ -138,6 +138,60 @@ describe('week utils', () => {
 
       expect(getDateForDayIndex(0)).toBe('2026-04-06')
       expect(getDateForDayIndex(4)).toBe('2026-04-10')
+    })
+  })
+
+  describe('getRecentWeekStarts', () => {
+    it('getRecentWeekStarts_ReturnsFiveMondaysInDescendingOrder_WhenCountIsFive', () => {
+      vi.setSystemTime(new Date('2026-04-08T12:00:00Z')) // Wednesday
+
+      expect(getRecentWeekStarts(5)).toEqual([
+        '2026-04-06',
+        '2026-03-30',
+        '2026-03-23',
+        '2026-03-16',
+        '2026-03-09',
+      ])
+    })
+
+    it('getRecentWeekStarts_ReturnsOnlyCurrentWeek_WhenCountIsOne', () => {
+      vi.setSystemTime(new Date('2026-04-08T12:00:00Z'))
+
+      expect(getRecentWeekStarts(1)).toEqual(['2026-04-06'])
+    })
+
+    it('getRecentWeekStarts_ReturnsEmptyArray_WhenCountIsZero', () => {
+      vi.setSystemTime(new Date('2026-04-08T12:00:00Z'))
+
+      expect(getRecentWeekStarts(0)).toEqual([])
+    })
+
+    it('getRecentWeekStarts_CrossesMonthBoundary_WhenWeekSpansMonths', () => {
+      vi.setSystemTime(new Date('2026-05-06T12:00:00Z')) // Wed in week of May 4
+
+      expect(getRecentWeekStarts(3)).toEqual([
+        '2026-05-04',
+        '2026-04-27',
+        '2026-04-20',
+      ])
+    })
+  })
+
+  describe('formatWeekRange', () => {
+    it('formatWeekRange_ReturnsAbbreviatedMonthWithDayOnly_WhenMondayAndFridayShareMonth', () => {
+      expect(formatWeekRange('2026-04-06')).toBe('Apr 6 \u2013 10')
+    })
+
+    it('formatWeekRange_ReturnsBothMonths_WhenFridayFallsInNextMonth', () => {
+      expect(formatWeekRange('2026-04-27')).toBe('Apr 27 \u2013 May 1')
+    })
+
+    it('formatWeekRange_HandlesYearEndWeek_WhenFridayIsInJanuary', () => {
+      expect(formatWeekRange('2026-12-28')).toBe('Dec 28 \u2013 Jan 1')
+    })
+
+    it('formatWeekRange_HandlesSingleDigitDays_WhenEarlyInMonth', () => {
+      expect(formatWeekRange('2026-03-02')).toBe('Mar 2 \u2013 6')
     })
   })
 

--- a/web/src/utils/week.ts
+++ b/web/src/utils/week.ts
@@ -35,3 +35,27 @@ export function getDateForDayIndex(dayIndex: number, weekStart?: string): string
   monday.setDate(monday.getDate() + dayIndex)
   return toLocalDateString(monday)
 }
+
+export function getRecentWeekStarts(count: number): string[] {
+  const result: string[] = []
+  const monday = parseLocalDate(getWeekStart())
+  for (let i = 0; i < count; i++) {
+    const d = new Date(monday)
+    d.setDate(monday.getDate() - i * 7)
+    result.push(toLocalDateString(d))
+  }
+  return result
+}
+
+const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+export function formatWeekRange(weekStart: string): string {
+  const monday = parseLocalDate(weekStart)
+  const friday = new Date(monday)
+  friday.setDate(monday.getDate() + 4)
+  const mondayLabel = `${SHORT_MONTHS[monday.getMonth()]} ${monday.getDate()}`
+  const fridayLabel = monday.getMonth() === friday.getMonth()
+    ? String(friday.getDate())
+    : `${SHORT_MONTHS[friday.getMonth()]} ${friday.getDate()}`
+  return `${mondayLabel} \u2013 ${fridayLabel}`
+}

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -33,6 +33,7 @@ const currentWeekStart = getWeekStart()
 const recentWeeks = getRecentWeekStarts(5)
 const selectedWeek = ref<string>(currentWeekStart)
 const isPastWeek = computed(() => selectedWeek.value !== currentWeekStart)
+const selectedWeekMonday = computed(() => new Date(`${selectedWeek.value}T00:00:00`))
 
 const modalTitle = computed(() => {
   switch (activeCommand.value) {
@@ -90,45 +91,45 @@ onMounted(() => {
               <span class="text-muted-foreground text-sm">v1.0.0</span>
             </h1>
             <p class="text-muted-foreground text-sm mt-1">
-              Weekly task tracker // {{ formatDate(launchTime) }}
+              Weekly task tracker //
+              <template v-if="view === 'weekly'">
+                <span>{{ formatDate(selectedWeekMonday) }}</span>
+                <span class="relative inline-block ml-1">
+                  <select
+                    v-model="selectedWeek"
+                    data-testid="week-dropdown"
+                    class="bg-transparent text-muted-foreground border-none outline-none cursor-pointer appearance-none pr-3"
+                  >
+                    <option
+                      v-for="(w, i) in recentWeeks"
+                      :key="w"
+                      :value="w"
+                      class="bg-card text-foreground"
+                    >
+                      {{ i === 0 ? '(current)' : `(${formatWeekRange(w)})` }}
+                    </option>
+                  </select>
+                  <span class="pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 text-muted-foreground">▾</span>
+                </span>
+              </template>
+              <template v-else>{{ formatDate(launchTime) }}</template>
             </p>
           </div>
 
           <!-- Navigation Box -->
           <div class="text-xs text-muted-foreground border border-border p-2 bg-card font-mono w-fit">
             <div>┌────────────────────────────┐</div>
-            <div class="flex items-center">
-              <span class="text-accent w-4">~</span>
-              <span> Week of:&nbsp;</span>
-              <select
-                v-model="selectedWeek"
-                data-testid="week-dropdown"
-                class="bg-transparent text-foreground border-none outline-none cursor-pointer"
-              >
-                <option
-                  v-for="(w, i) in recentWeeks"
-                  :key="w"
-                  :value="w"
-                  class="bg-card text-foreground"
-                >
-                  {{ formatWeekRange(w) }}{{ i === 0 ? ' (current)' : '' }}
-                </option>
-              </select>
-              <span class="ml-auto">│</span>
-            </div>
             <button
-              v-if="!isPastWeek"
               type="button"
               class="flex w-full hover:bg-secondary/50 transition-colors"
               :aria-pressed="view === 'weekly'"
               @click="view = 'weekly'"
             >
               <span class="text-accent w-4">{{ view === 'weekly' ? '~' : ' ' }}</span>
-              <span> View: Weekly</span>
+              <span> Week of: {{ dailyTasks.weekOf }}</span>
               <span class="ml-auto">│</span>
             </button>
             <button
-              v-if="!isPastWeek"
               type="button"
               class="flex w-full hover:bg-secondary/50 transition-colors"
               :aria-pressed="view === 'daily'"

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -133,7 +133,7 @@ onMounted(() => {
               type="button"
               class="flex w-full hover:bg-secondary/50 transition-colors"
               :aria-pressed="view === 'daily'"
-              @click="view = 'daily'"
+              @click="view = 'daily'; selectedWeek = currentWeekStart"
             >
               <span class="text-accent w-4">{{ view === 'daily' ? '~' : ' ' }}</span>
               <span> Day: {{ currentDayLabel }}</span>

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -4,7 +4,7 @@ import { useWorkItemsStore } from '@/stores/workItems'
 import { useReadWatchStore } from '@/stores/readWatch'
 import { useDailyTasksStore } from '@/stores/dailyTasks'
 import { useScratchPadStore } from '@/stores/scratchPad'
-import { DAYS, getToday, getWeekStart } from '@/utils/week'
+import { DAYS, getWeekStart, getRecentWeekStarts, formatWeekRange } from '@/utils/week'
 import type { CommandType } from '@/types'
 import BigThing from '@/components/BigThing.vue'
 import DailyTasks from '@/components/DailyTasks.vue'
@@ -16,6 +16,7 @@ import StatsPanel from '@/components/StatsPanel.vue'
 import SlashCommandMenu from '@/components/SlashCommandMenu.vue'
 import CommandModal from '@/components/CommandModal.vue'
 import EvaluateWeekModal from '@/components/EvaluateWeekModal.vue'
+import PastWeekView from '@/components/PastWeekView.vue'
 
 type ViewMode = 'daily' | 'weekly'
 
@@ -27,6 +28,11 @@ const scratchPad = useScratchPadStore()
 const launchTime = new Date()
 const view = ref<ViewMode>('daily')
 const activeCommand = ref<CommandType | null>(null)
+
+const currentWeekStart = getWeekStart()
+const recentWeeks = getRecentWeekStarts(5)
+const selectedWeek = ref<string>(currentWeekStart)
+const isPastWeek = computed(() => selectedWeek.value !== currentWeekStart)
 
 const modalTitle = computed(() => {
   switch (activeCommand.value) {
@@ -51,14 +57,6 @@ function formatDate(date: Date): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-  })
-}
-
-function formatTime(date: Date): string {
-  return date.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
   })
 }
 
@@ -92,24 +90,45 @@ onMounted(() => {
               <span class="text-muted-foreground text-sm">v1.0.0</span>
             </h1>
             <p class="text-muted-foreground text-sm mt-1">
-              Weekly task tracker // {{ formatDate(launchTime) }} {{ formatTime(launchTime) }}
+              Weekly task tracker // {{ formatDate(launchTime) }}
             </p>
           </div>
 
           <!-- Navigation Box -->
           <div class="text-xs text-muted-foreground border border-border p-2 bg-card font-mono w-fit">
             <div>┌────────────────────────────┐</div>
+            <div class="flex items-center">
+              <span class="text-accent w-4">~</span>
+              <span> Week of:&nbsp;</span>
+              <select
+                v-model="selectedWeek"
+                data-testid="week-dropdown"
+                class="bg-transparent text-foreground border-none outline-none cursor-pointer"
+              >
+                <option
+                  v-for="(w, i) in recentWeeks"
+                  :key="w"
+                  :value="w"
+                  class="bg-card text-foreground"
+                >
+                  {{ formatWeekRange(w) }}{{ i === 0 ? ' (current)' : '' }}
+                </option>
+              </select>
+              <span class="ml-auto">│</span>
+            </div>
             <button
+              v-if="!isPastWeek"
               type="button"
               class="flex w-full hover:bg-secondary/50 transition-colors"
               :aria-pressed="view === 'weekly'"
               @click="view = 'weekly'"
             >
               <span class="text-accent w-4">{{ view === 'weekly' ? '~' : ' ' }}</span>
-              <span> Week of: {{ dailyTasks.weekOf }}</span>
+              <span> View: Weekly</span>
               <span class="ml-auto">│</span>
             </button>
             <button
+              v-if="!isPastWeek"
               type="button"
               class="flex w-full hover:bg-secondary/50 transition-colors"
               :aria-pressed="view === 'daily'"
@@ -128,9 +147,9 @@ onMounted(() => {
         </div>
       </header>
 
-      <SlashCommandMenu @command="handleCommand" />
+      <SlashCommandMenu v-if="!isPastWeek" @command="handleCommand" />
 
-      <BigThing />
+      <BigThing v-if="!isPastWeek" />
 
       <CommandModal
         :is-open="activeCommand !== null && activeCommand !== 'evaluate-my-week'"
@@ -145,8 +164,11 @@ onMounted(() => {
         @close="activeCommand = null"
       />
 
+      <!-- Past Week (read-only) -->
+      <PastWeekView v-if="isPastWeek" :key="selectedWeek" :week-of="selectedWeek" />
+
       <!-- Daily View -->
-      <main v-if="view === 'daily'" class="space-y-6 mt-6">
+      <main v-if="!isPastWeek && view === 'daily'" class="space-y-6 mt-6">
         <DailyTasksCompact />
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <ScratchPad />
@@ -155,7 +177,7 @@ onMounted(() => {
       </main>
 
       <!-- Weekly View -->
-      <main v-if="view === 'weekly'" class="space-y-6 mt-6">
+      <main v-if="!isPastWeek && view === 'weekly'" class="space-y-6 mt-6">
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div class="lg:col-span-2"><WeekOverview /></div>
           <div><StatsPanel /></div>


### PR DESCRIPTION
## Summary
- Week dropdown replaces the static "Week of:" label — shows current + past 4 weeks as friendly ranges (`Apr 6 – 10`), crossing month/year boundaries
- Selecting a past week renders a new read-only `PastWeekView`: BigThing objective, Mon-Fri task grid with `✓`/`☐` markers (no actions), `StatsPanel` (refactored to accept items as a prop), consumed-learnings table (Title w/ link, Shareable, Commentary → Notes)
- Bottom of the past-week view shows a blinking `[G]enerate a weekly summary` block. Pressing **G** outside an input fires a new `POST /api/standup/generate-weekly-summary?weekOf=…` which feeds the week's `DailyStandupComm` rows to OpenAI and persists the result as a new `WeeklySummaryComm` subtype of `UpdateComm`. Existing summaries render directly on load instead of the prompt.
- Small polish: dropped the clock time from the header subtitle on both daily and weekly views

## Test plan
- [x] `cd api/tests && dotnet test --filter "FullyQualifiedName~StandupEndpointTests"` — 8/8 pass (incl. 2 new weekly-summary tests)
- [x] `cd web && npx vitest run` — 102/102 pass (incl. 5 new `PastWeekView.spec.ts` tests + 8 new `week.spec.ts` tests for `getRecentWeekStarts` / `formatWeekRange`)
- [ ] Manual: start Aspire, switch to a past week, verify read-only rendering, press G, confirm the summary renders and persists across reloads
- [ ] Manual: confirm current-week behavior is unchanged when the dropdown is on the current week

## Notes
- No EF migration — `WeeklySummaryComm` is only a new discriminator value on the existing `UpdateComms` table
- Pre-existing `ReadWatchEndpointTests` failures are unrelated and tracked in #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)