### PR TITLE
fix(api): pass client local date to standup generate endpoint

### DIFF
--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -68,7 +68,7 @@ internal static class StandupEndpoints
             IChatCompletionService? chatService,
             string? weekOf,
             string? commandType,
-            string? today) =>
+            DateOnly? today) =>
         {
             if (chatService is null)
                 return Results.Problem("Azure OpenAI is not configured.", statusCode: 503);
@@ -76,9 +76,7 @@ internal static class StandupEndpoints
             if (weekOf is null)
                 return Results.BadRequest("weekOf query parameter is required.");
 
-            var todayDate = today is not null
-                ? DateOnly.Parse(today, CultureInfo.InvariantCulture)
-                : dateTime.UtcToday;
+            var todayDate = today ?? dateTime.UtcToday;
 
             var items = await db.WorkItems
                 .AsNoTracking()

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -67,7 +67,8 @@ internal static class StandupEndpoints
             IDateTimeProvider dateTime,
             IChatCompletionService? chatService,
             string? weekOf,
-            string? commandType) =>
+            string? commandType,
+            string? today) =>
         {
             if (chatService is null)
                 return Results.Problem("Azure OpenAI is not configured.", statusCode: 503);
@@ -75,7 +76,9 @@ internal static class StandupEndpoints
             if (weekOf is null)
                 return Results.BadRequest("weekOf query parameter is required.");
 
-            var today = dateTime.UtcToday;
+            var todayDate = today is not null
+                ? DateOnly.Parse(today, CultureInfo.InvariantCulture)
+                : dateTime.UtcToday;
 
             var items = await db.WorkItems
                 .AsNoTracking()
@@ -90,7 +93,7 @@ internal static class StandupEndpoints
                 return Results.BadRequest("No work items found for the specified week.");
 
             // For Monday prompts or weekly command, also fetch previous week's items
-            var dayOfWeek = today.DayOfWeek;
+            var dayOfWeek = todayDate.DayOfWeek;
             var useWeeklyPrompt = string.Equals(commandType, "weekly", StringComparison.OrdinalIgnoreCase);
 
             if (dayOfWeek == DayOfWeek.Monday || useWeeklyPrompt)
@@ -133,7 +136,7 @@ internal static class StandupEndpoints
 
             var chatHistory = new ChatHistory();
             chatHistory.AddSystemMessage(systemPrompt);
-            chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(workItemsJson, today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), learningQueueJson));
+            chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(workItemsJson, todayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), learningQueueJson));
 
             var response = await chatService.GetChatMessageContentAsync(chatHistory);
 

--- a/api/src/Playground/Standup.http
+++ b/api/src/Playground/Standup.http
@@ -1,11 +1,11 @@
-@host = http://localhost:5062
+@host = http://localhost:5224
 
 ### Generate standup (mid-week, current week)
-POST {{host}}/api/standup/generate?weekOf=2026-04-06
+POST {{host}}/api/standup/generate?weekOf=2026-04-06&today=2026-04-08
 Content-Type: application/json
 
 ### Generate standup (weekly summary)
-POST {{host}}/api/standup/generate?weekOf=2026-04-06&commandType=weekly
+POST {{host}}/api/standup/generate?weekOf=2026-04-06&commandType=weekly&today=2026-04-10
 Content-Type: application/json
 
 ### Generate standup (no items — expects 400)

--- a/api/src/Properties/launchSettings.json
+++ b/api/src/Properties/launchSettings.json
@@ -1,11 +1,11 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5062",
+      "applicationUrl": "http://localhost:5224",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -44,8 +44,8 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
             Date = "2020-01-15",
         });
 
-        // Act
-        var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}", null);
+        // Act — pass today explicitly (client's local date)
+        var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -53,6 +53,28 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
         var markdown = result.GetProperty("markdown").GetString();
         markdown.ShouldNotBeNull();
         markdown.ShouldContain("Crushed it");
+    }
+
+    [Fact]
+    public async Task GenerateStandup_FallsBackToUtc_WhenTodayNotProvided()
+    {
+        // Arrange
+        _factory.ChatCompletionService.ResponseContent = "Fallback test";
+
+        await _client.PostAsJsonAsync("/api/work-items", new
+        {
+            Title = "Fallback item",
+            Category = "SmallThing",
+            Date = "2020-01-15",
+        });
+
+        // Act — omit today param
+        var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}", null);
+
+        // Assert — should still succeed using UtcToday fallback
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        result.GetProperty("markdown").GetString().ShouldNotBeNull();
     }
 
     [Fact]

--- a/web/src/components/CommandModal.vue
+++ b/web/src/components/CommandModal.vue
@@ -122,7 +122,7 @@ async function generate() {
   startDotAnimation()
 
   try {
-    const params: Record<string, string> = { weekOf }
+    const params: Record<string, string> = { weekOf, today: getToday() }
     if (commandType === 'weekly') params.commandType = 'weekly'
 
     const data = await client.post('/api/standup/generate', null, { params }) as any


### PR DESCRIPTION
## Summary

- The `/api/standup/generate` endpoint used `dateTime.UtcToday` to tell the AI what "today" is, causing the standup to pull the wrong day's tasks when UTC differs from the client's local date
- Added a `today` query parameter so the frontend passes its local date; the endpoint falls back to `UtcToday` if omitted
- Frontend `CommandModal.vue` now sends `today: getToday()` alongside `weekOf`

## Test plan

- [x] API integration tests pass (51/51), including new fallback test
- [ ] Manual: generate a daily standup mid-week and verify "yesterday" shows the correct day's tasks
- [ ] Manual: verify standup still generates if `today` param is omitted (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)