### PR TITLE
fix(api): pass yesterday date explicitly in standup prompt

### DIFF
--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -77,9 +77,13 @@ internal static class StandupEndpoints
                 return Results.BadRequest("weekOf query parameter is required.");
 
             var todayDate = today ?? dateTime.UtcToday;
-            // Mid-week (Tue-Fri) yesterday is simply today - 1 day.
-            // Monday support is TODO (would need weekend adjustment to Friday).
-            var yesterdayDate = todayDate.AddDays(-1);
+            // Roll "yesterday" back over the weekend so Mon/Sat/Sun all point to Friday.
+            var yesterdayDate = todayDate.DayOfWeek switch
+            {
+                DayOfWeek.Monday => todayDate.AddDays(-3),
+                DayOfWeek.Sunday => todayDate.AddDays(-2),
+                _ => todayDate.AddDays(-1),
+            };
 
             var items = await db.WorkItems
                 .AsNoTracking()

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -77,6 +77,9 @@ internal static class StandupEndpoints
                 return Results.BadRequest("weekOf query parameter is required.");
 
             var todayDate = today ?? dateTime.UtcToday;
+            // Mid-week (Tue-Fri) yesterday is simply today - 1 day.
+            // Monday support is TODO (would need weekend adjustment to Friday).
+            var yesterdayDate = todayDate.AddDays(-1);
 
             var items = await db.WorkItems
                 .AsNoTracking()
@@ -134,7 +137,11 @@ internal static class StandupEndpoints
 
             var chatHistory = new ChatHistory();
             chatHistory.AddSystemMessage(systemPrompt);
-            chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(workItemsJson, todayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), learningQueueJson));
+            chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(
+                workItemsJson,
+                todayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                yesterdayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                learningQueueJson));
 
             var response = await chatService.GetChatMessageContentAsync(chatHistory);
 

--- a/api/src/Prompts/StandupPrompts.cs
+++ b/api/src/Prompts/StandupPrompts.cs
@@ -9,9 +9,9 @@ internal static class StandupPrompts
         _ => GetMidWeekPrompt(),
     };
 
-    internal static string BuildUserMessage(string workItemsJson, string today, string? learningQueueJson = null)
+    internal static string BuildUserMessage(string workItemsJson, string today, string yesterday, string? learningQueueJson = null)
     {
-        var message = $"Today's date: {today}\n\nWork items:\n{workItemsJson}";
+        var message = $"Today's date: {today}\nYesterday's date: {yesterday}\n\nWork items:\n{workItemsJson}";
         if (learningQueueJson is not null)
             message += $"\n\nLearning queue items consumed this week:\n{learningQueueJson}";
         return message;
@@ -34,13 +34,13 @@ internal static class StandupPrompts
 
         Smaller stuff: knocked out **Weekly Kickoff Prep**, carried **Graham CRM+ discussion** and **Submit AI Qualifying Race**.
 
-        The first line addresses ONLY yesterday's big thing of the day (the first SmallThing by sortOrder for yesterday's date). Lead with an opener that varies based on whether THAT specific item was done:
+        The first line addresses ONLY yesterday's big thing of the day — the first SmallThing (by sortOrder) whose `date` EXACTLY matches the "Yesterday's date" line provided in the user message. Do NOT infer yesterday from today's date; use the value given. Lead with an opener that varies based on whether THAT specific item was done:
         - DONE: enthusiastic — pick one: "Hell yea!", "YESSIR!", "You know it!", "YES!", "Crushed it.", "Nailed it.", "Lock it in.", "Big day yesterday.", "Clean sweep.", "All green, baby."
         - NOT DONE: self-deprecating — pick one: "NOPE.", "That's funny.", "Not even close.", "What was I thinking?", "Lol no.", "About that...", "Let's not talk about it.", "Swing and a miss.", "Bold of you to ask.", "Yeah... no."
         - PARTIAL CREDIT (e.g. in progress): hedging — pick one: "Kinda.", "Sort of.", "Getting there.", "Halfway hero.", "Progress, not perfection."
         Pick a different one each time — never repeat the same opener twice in a row.
 
-        Then a BLANK LINE, then a "Smaller stuff:" line summarizing yesterday's other SmallThings (done/carried).
+        Then a BLANK LINE, then a "Smaller stuff:" line summarizing the other SmallThings whose `date` matches the provided yesterday's date (done/carried).
 
         ### What's the One Thing you will complete today in service of the weekly goal?
         **Start Insights work — examine PDL payload/data store**, feeding the weekly goal of **Data Products support**.
@@ -87,13 +87,13 @@ internal static class StandupPrompts
 
         Smaller stuff: knocked out **Weekly Kickoff Prep**, carried **Graham CRM+ discussion** and **Submit AI Qualifying Race**.
 
-        The first line addresses ONLY yesterday's big thing of the day (the first SmallThing by sortOrder for yesterday's date). Lead with an opener that varies based on whether THAT specific item was done:
+        The first line addresses ONLY yesterday's big thing of the day — the first SmallThing (by sortOrder) whose `date` EXACTLY matches the "Yesterday's date" line provided in the user message. Do NOT infer yesterday from today's date; use the value given. Lead with an opener that varies based on whether THAT specific item was done:
         - DONE: enthusiastic — pick one: "Hell yea!", "YESSIR!", "You know it!", "YES!", "Crushed it.", "Nailed it.", "Lock it in.", "Big day yesterday.", "Clean sweep.", "All green, baby."
         - NOT DONE: self-deprecating — pick one: "NOPE.", "That's funny.", "Not even close.", "What was I thinking?", "Lol no.", "About that...", "Let's not talk about it.", "Swing and a miss.", "Bold of you to ask.", "Yeah... no."
         - PARTIAL CREDIT (e.g. in progress): hedging — pick one: "Kinda.", "Sort of.", "Getting there.", "Halfway hero.", "Progress, not perfection."
         Pick a different one each time — never repeat the same opener twice in a row.
 
-        Then a BLANK LINE, then a "Smaller stuff:" line summarizing yesterday's other SmallThings (done/carried).
+        Then a BLANK LINE, then a "Smaller stuff:" line summarizing the other SmallThings whose `date` matches the provided yesterday's date (done/carried).
 
         ### What's the One Thing you will complete today in service of the weekly goal?
         **Start Insights work — examine PDL payload/data store**, feeding the weekly goal of **Data Products support**.

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DailyWork.Api.Tests.Fixtures;
+using Microsoft.SemanticKernel.ChatCompletion;
 using Shouldly;
 using Xunit;
 
@@ -53,6 +54,31 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
         var markdown = result.GetProperty("markdown").GetString();
         markdown.ShouldNotBeNull();
         markdown.ShouldContain("Crushed it");
+    }
+
+    [Fact]
+    public async Task GenerateStandup_IncludesYesterdayDateInPrompt_WhenGenerating()
+    {
+        // Arrange
+        _factory.ChatCompletionService.ResponseContent = "ok";
+
+        await _client.PostAsJsonAsync("/api/work-items", new
+        {
+            Title = "Yesterday test item",
+            Category = "SmallThing",
+            Date = "2020-01-14",
+        });
+
+        // Act — today is Wednesday 2020-01-15, so yesterday should be 2020-01-14
+        var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var userMessage = _factory.ChatCompletionService.LastChatHistory!
+            .Last(m => m.Role == AuthorRole.User)
+            .Content!;
+        userMessage.ShouldContain("Today's date: 2020-01-15");
+        userMessage.ShouldContain("Yesterday's date: 2020-01-14");
     }
 
     [Fact]

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -82,6 +82,32 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
     }
 
     [Fact]
+    public async Task GenerateStandup_RollsYesterdayBackToFriday_WhenTodayIsMonday()
+    {
+        // Arrange
+        _factory.ChatCompletionService.ResponseContent = "ok";
+
+        // Seed a work item in the Monday week so items.Count > 0
+        await _client.PostAsJsonAsync("/api/work-items", new
+        {
+            Title = "Monday item",
+            Category = "SmallThing",
+            Date = "2020-01-20",
+        });
+
+        // Act — today is Monday 2020-01-20, yesterday should roll back to Friday 2020-01-17
+        var response = await _client.PostAsync("/api/standup/generate?weekOf=2020-01-20&today=2020-01-20", null);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var userMessage = _factory.ChatCompletionService.LastChatHistory!
+            .Last(m => m.Role == AuthorRole.User)
+            .Content!;
+        userMessage.ShouldContain("Today's date: 2020-01-20");
+        userMessage.ShouldContain("Yesterday's date: 2020-01-17");
+    }
+
+    [Fact]
     public async Task GenerateStandup_FallsBackToUtc_WhenTodayNotProvided()
     {
         // Arrange

--- a/api/tests/StandupPromptTests.cs
+++ b/api/tests/StandupPromptTests.cs
@@ -62,13 +62,14 @@ public class StandupPromptTests
     }
 
     [Fact]
-    public void BuildUserMessage_IncludesTodayAndJson()
+    public void BuildUserMessage_IncludesTodayAndYesterdayAndJson()
     {
         var json = """[{"id":1,"title":"Test"}]""";
 
-        var message = StandupPrompts.BuildUserMessage(json, "2026-04-07");
+        var message = StandupPrompts.BuildUserMessage(json, "2026-04-07", "2026-04-06");
 
         message.ShouldContain("Today's date: 2026-04-07");
+        message.ShouldContain("Yesterday's date: 2026-04-06");
         message.ShouldContain(json);
         message.ShouldNotContain("Learning queue");
     }
@@ -79,9 +80,10 @@ public class StandupPromptTests
         var workJson = """[{"id":1,"title":"Test"}]""";
         var learningJson = """[{"title":"Cool experiment","type":"Experiment"}]""";
 
-        var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-10", learningJson);
+        var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-10", "2026-04-09", learningJson);
 
         message.ShouldContain("Today's date: 2026-04-10");
+        message.ShouldContain("Yesterday's date: 2026-04-09");
         message.ShouldContain(workJson);
         message.ShouldContain("Learning queue items consumed this week");
         message.ShouldContain(learningJson);


### PR DESCRIPTION
## Summary

- Even after PR #48 fixed the timezone issue, the standup's "Did you complete your One Thing yesterday?" section was still consistently referencing the wrong day (off by one — e.g. Tuesday when yesterday was Wednesday)
- Root cause: the prompt told the AI today's date and expected it to infer yesterday and match it against the `date` fields in the work items JSON. That inference was unreliable
- Fix: pre-compute `yesterday = today - 1` on the backend and include it in the user message alongside today. Tightened the mid-week and Friday prompts to reference the provided yesterday value instead of inferring it

## Test plan

- [x] API tests pass (51/51) — new assertion verifies `Yesterday's date:` is in the user message
- [x] `BuildUserMessage` unit tests updated for new signature
- [ ] Manual: generate today's standup and confirm "yesterday" now references the correct day's tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)