### PR TITLE
chore: ignore .claude/worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ dist/
 # Prototypes and Ephemeral Assets
 prototypes/
 /.claude/settings.local.json
+/.claude/worktrees/
 prev-context/


### PR DESCRIPTION
## Summary
- Adds `/.claude/worktrees/` to `.gitignore` so Claude Code worktrees are not tracked or shown as uncommitted changes

## Test plan
- [ ] Verify `.claude/worktrees/` no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)