### PR TITLE
docs: add formatting and lint rules to CLAUDE.md and coding conventions

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -121,6 +121,17 @@ Log levels: `Information` for successful mutations, `Warning` for business rule 
 - Use `[]` collection expression syntax (C# 12+) where applicable
 - Use `var` for locals where the type is obvious from the right side
 
+## Formatting
+
+All formatting is enforced by `.editorconfig` and `dotnet format`. Follow these or the pre-push hook will block:
+
+- **Indentation**: tabs (width 4) for `.cs` — never spaces
+- **Namespaces**: file-scoped (`namespace Foo;`)
+- **Braces**: single-line early exits without braces are OK (`when_multiline`); open braces always on a new line
+- **`using` directives**: system namespaces sorted first
+
+Run `dotnet format api/src` and `dotnet format api/tests` after making C# changes and commit the result before pushing.
+
 ## Keep It Simple
 
 This is an intentionally minimal dev tool. No FluentValidation, no auth middleware, no output caching, no Options pattern. Business rule validation (e.g., max 5 items/day) is inline in the endpoint handler:

--- a/.claude/rules/vue.md
+++ b/.claude/rules/vue.md
@@ -79,6 +79,28 @@ Never use `bg-white`, `text-black`, `text-gray-*`, or hardcoded hex/rgb colors.
 
 **Exception:** Component-local constant maps (like `TYPE_STYLES` in `ReadWatchItem.vue`) may use Tailwind color classes for label badge coloring.
 
+## Linting
+
+ESLint runs with `--max-warnings 0` — warnings are treated as errors. A pre-push hook blocks if lint fails. Keep these rules in mind:
+
+- **No unused variables** — `@typescript-eslint/no-unused-vars` is an error; remove or use every declared variable
+- **Multiline element content** — `vue/multiline-html-element-content-newline` is active: if a `<div>` (or block element) spans multiple lines of attributes, its content must be on its own line:
+  ```html
+  <!-- CORRECT -->
+  <div class="...">
+    {{ value }}
+  </div>
+
+  <!-- WRONG — content on same line as closing > -->
+  <div class="...">{{ value }}</div>
+  ```
+- **Optional prop defaults** — `vue/require-default-prop` is active; always provide defaults for optional props via reactive destructure:
+  ```ts
+  const { count = 0, items = [] } = defineProps<{ count?: number; items?: Foo[] }>()
+  ```
+
+Turned **off** in this project (don't add them back): `no-explicit-any`, `no-v-html`, `max-attributes-per-line`, `singleline-html-element-content-newline`, `html-self-closing`, `multi-word-component-names`, `html-indent`, `html-closing-bracket-newline`, `first-attribute-linebreak`.
+
 ## CLI Aesthetic
 
 The app has a terminal/CLI aesthetic — maintain it in new UI:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,11 @@ All conventions live in `.claude/rules/`. Read the relevant file before touching
 1. **Implement** — features typically touch both `api` and `web` in the same branch/PR
 2. **Test** — write API integration tests (xUnit + Testcontainers) and Vue component tests (Vitest) alongside every feature
 3. **Migrate** — when schema changes, add an EF Core migration from `api/src/` and verify `Up()`/`Down()`
-4. **PR** — open a PR; GitHub Copilot will auto-review
-5. **Triage feedback** — use `/pr-feedback` to triage Copilot review comments into Address Now / Backlog / Ignore
-6. **Manual test** — always verify the running Aspire app before merging
+4. **Format** — run `dotnet format api/src` and `dotnet format api/tests`; commit any changes before pushing
+5. **Lint** — run `npm run lint` from `web/`; fix all errors and warnings before pushing
+6. **PR** — open a PR; GitHub Copilot will auto-review
+7. **Triage feedback** — use `/pr-feedback` to triage Copilot review comments into Address Now / Backlog / Ignore
+8. **Manual test** — always verify the running Aspire app before merging
 
 ## Slash Commands
 


### PR DESCRIPTION
## Summary

- Adds a `## Formatting` section to `api.md` documenting tab indentation, file-scoped namespaces, brace style, and the `dotnet format` + commit requirement
- Adds a `## Linting` section to `vue.md` calling out the three ESLint rules that bite in practice (`no-unused-vars`, multiline element content newlines, optional prop defaults) and listing the rules that are explicitly turned off
- Adds Format and Lint as steps 4 and 5 in the Development Workflow in `CLAUDE.md`

## Test plan

- [ ] Verify `CLAUDE.md` workflow steps read clearly
- [ ] Verify `api.md` formatting section matches `.editorconfig`
- [ ] Verify `vue.md` linting section matches `eslint.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)