### PR TITLE
chore: improve grill-me and create-adr slash commands

### DIFF
--- a/.claude/commands/create-adr.md
+++ b/.claude/commands/create-adr.md
@@ -23,8 +23,21 @@ If no ADRs exist yet, start at `ADR-0001`.
 
 ## Step 3 — Draft the ADR
 
-Fill in the template below from the current conversation context. Do not invent details — only record what was actually decided and discussed.
+Fill in the structure below from the current conversation context. Do not invent details — only record what was actually decided and discussed.
 
+An ADR can be as short as a single paragraph if the context, decision, and reasoning are clear. Only expand into sections when the trade-offs are genuinely complex and warrant the structure.
+
+**Minimal form** (use when straightforward):
+```
+# ADR-NNNN: {Title}
+
+**Date:** {today's date}
+**Status:** Accepted
+
+{One or two paragraphs: what situation forced the decision, what was decided, and why — including why alternatives were not chosen.}
+```
+
+**Full form** (use when trade-offs are complex):
 ```
 # ADR-NNNN: {Title}
 

--- a/.claude/commands/grill-me.md
+++ b/.claude/commands/grill-me.md
@@ -6,13 +6,19 @@ The user wants to be interviewed about a plan or idea before implementation begi
 
 1. If $ARGUMENTS is non-empty, treat it as the plan or feature the user wants to discuss. Otherwise, ask them to briefly describe what they're planning.
 
-2. Interview them relentlessly. Ask one focused question at a time. Do not ask multiple questions in the same message — it lets the user dodge the harder one. For each question, provide your own recommended answer — you should have a stake in the conversation, not just ask questions.
+2. Before the first question, read `CONTEXT.md` if it exists. Use it to:
+   - Anchor your questions in established vocabulary
+   - Flag any terminology the user uses that conflicts with or is absent from the glossary
+   - Note new terms that crystallize during the session — offer to add them to `CONTEXT.md` as they solidify (one at a time, not batched at the end)
+   If `CONTEXT.md` doesn't exist or nothing in it is relevant, skip this step silently and proceed.
 
-3. If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+3. Interview them relentlessly. Ask one focused question at a time. Do not ask multiple questions in the same message — it lets the user dodge the harder one. For each question, provide your own recommended answer — you should have a stake in the conversation, not just ask questions.
 
-4. Walk the design tree depth-first: pick the most load-bearing decision or dependency and drill into it until it's fully resolved before moving to the next branch.
+4. If a question can be answered by exploring the codebase, explore the codebase instead of asking.
 
-5. Press on these areas whenever they appear:
+5. Walk the design tree depth-first: pick the most load-bearing decision or dependency and drill into it until it's fully resolved before moving to the next branch.
+
+6. Press on these areas whenever they appear:
    - **Scope** — what is explicitly out of scope, and why?
    - **Data model** — what entities, relationships, and constraints does this touch?
    - **API contract** — what are the exact request/response shapes?
@@ -22,9 +28,9 @@ The user wants to be interviewed about a plan or idea before implementation begi
    - **Sequencing** — what must be built first? What can be deferred?
    - **Test strategy** — how will correctness be verified for each piece?
 
-6. When the user gives a vague or hand-wavy answer, do not accept it. Rephrase and ask again with a concrete example or counter-scenario to force precision.
+7. When the user gives a vague or hand-wavy answer, do not accept it. Rephrase and ask again with a concrete example or counter-scenario to force precision.
 
-7. Keep going until every major branch of the design tree has a concrete, agreed answer. Then summarize the full plan as a numbered implementation checklist the user can hand back to you as a task.
+8. Keep going until every major branch of the design tree has a concrete, agreed answer. Then summarize the full plan as a numbered implementation checklist the user can hand back to you as a task. After the summary, scan the decisions made and suggest running `/create-adr` for any that are hard to reverse, would surprise a future reader, and represent a genuine trade-off.
 
 ## Tone
 

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,15 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.


### PR DESCRIPTION
## Summary

- Updated `/grill-me` to read `CONTEXT.md` before the interview, anchor questions in established vocabulary, flag terminology conflicts, and offer inline glossary updates as terms crystallize
- Added a final step to `/grill-me` that suggests `/create-adr` for any qualifying decisions after the implementation checklist
- Updated `/create-adr` to allow a minimal single-paragraph form for straightforward decisions; full 4-section template is now reserved for genuinely complex trade-offs

## Test plan

- [ ] Run `/grill-me` on a new feature — verify it reads CONTEXT.md and anchors terminology
- [ ] Run `/grill-me` on a topic with no CONTEXT.md relevance — verify it proceeds silently without disruption
- [ ] Run `/create-adr` after a simple decision — verify minimal form is used
- [ ] Run `/create-adr` after a complex trade-off — verify full form is offered

🤖 Generated with [Claude Code](https://claude.com/claude-code)