### PR TITLE
feat: add /punch slash command to adjust clock-in and clock-out times

### DIFF
--- a/api/src/Dtos/WorkSessionDtos.cs
+++ b/api/src/Dtos/WorkSessionDtos.cs
@@ -1,0 +1,3 @@
+namespace DailyWork.Api.Dtos;
+
+internal record PunchWorkSessionDto(DateTime? ClockedInAt, DateTime? ClockedOutAt);

--- a/api/src/Endpoints/WorkSessionEndpoints.cs
+++ b/api/src/Endpoints/WorkSessionEndpoints.cs
@@ -1,4 +1,5 @@
 using DailyWork.Api.Data;
+using DailyWork.Api.Dtos;
 using DailyWork.Api.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -65,6 +66,37 @@ internal static class WorkSessionEndpoints
 				await db.SaveChangesAsync();
 			}
 
+			return Results.Ok(session);
+		});
+
+		group.MapPut("/", async (AppDbContext db, IDateTimeProvider dateTime, PunchWorkSessionDto dto, DateOnly date) =>
+		{
+			if (dto.ClockedOutAt.HasValue && !dto.ClockedInAt.HasValue)
+				return Results.Problem("Cannot set clock-out without clock-in", statusCode: 422);
+
+			if (dto.ClockedInAt.HasValue && dto.ClockedOutAt.HasValue && dto.ClockedOutAt.Value <= dto.ClockedInAt.Value)
+				return Results.Problem("Clock-out must be after clock-in", statusCode: 422);
+
+			var session = await db.WorkSessions.SingleOrDefaultAsync(s => s.Date == date);
+
+			if (session is null)
+			{
+				session = new WorkSession
+				{
+					Date = date,
+					ClockedInAt = dto.ClockedInAt,
+					ClockedOutAt = dto.ClockedOutAt,
+					CreatedAt = dateTime.UtcNow,
+				};
+				db.WorkSessions.Add(session);
+			}
+			else
+			{
+				session.ClockedInAt = dto.ClockedInAt;
+				session.ClockedOutAt = dto.ClockedOutAt;
+			}
+
+			await db.SaveChangesAsync();
 			return Results.Ok(session);
 		});
 

--- a/api/tests/WorkSessionEndpointTests.cs
+++ b/api/tests/WorkSessionEndpointTests.cs
@@ -32,6 +32,7 @@ public class WorkSessionEndpointTests : IClassFixture<CustomWebApplicationFactor
 	private string GetTodayUrl => $"/api/work-sessions?date={Today}";
 	private string ClockInUrl => $"/api/work-sessions/clock-in?date={Today}";
 	private string ClockOutUrl => $"/api/work-sessions/clock-out?date={Today}";
+	private string PunchUrl => $"/api/work-sessions?date={Today}";
 
 	[Fact]
 	public async Task GetToday_Returns204_WhenNoSessionExists()
@@ -159,5 +160,100 @@ public class WorkSessionEndpointTests : IClassFixture<CustomWebApplicationFactor
 		secondSession.ShouldNotBeNull();
 		secondSession.Id.ShouldBe(firstSession.Id);
 		secondSession.ClockedOutAt.ShouldBe(originalClockOutAt);
+	}
+
+	[Fact]
+	public async Task PutPunch_CreatesSession_WhenNoneExists()
+	{
+		// Arrange
+		var clockIn = _factory.DateTimeProvider.UtcNow.AddHours(-8);
+		var clockOut = _factory.DateTimeProvider.UtcNow;
+		var payload = new { ClockedInAt = clockIn, ClockedOutAt = clockOut };
+
+		// Act
+		var response = await _client.PutAsJsonAsync(PunchUrl, payload);
+
+		// Assert
+		response.EnsureSuccessStatusCode();
+		var session = await response.Content.ReadFromJsonAsync<WorkSession>(JsonOptions);
+		session.ShouldNotBeNull();
+		session.Date.ShouldBe(_factory.DateTimeProvider.UtcToday);
+		session.ClockedInAt.ShouldBe(clockIn);
+		session.ClockedOutAt.ShouldBe(clockOut);
+	}
+
+	[Fact]
+	public async Task PutPunch_UpdatesExistingSession_WithNewTimes()
+	{
+		// Arrange
+		await _client.PostAsJsonAsync(ClockInUrl, new { });
+		var newClockIn = _factory.DateTimeProvider.UtcNow.AddHours(-4);
+		var newClockOut = _factory.DateTimeProvider.UtcNow;
+		var payload = new { ClockedInAt = newClockIn, ClockedOutAt = newClockOut };
+
+		// Act
+		var response = await _client.PutAsJsonAsync(PunchUrl, payload);
+
+		// Assert
+		response.EnsureSuccessStatusCode();
+		var session = await response.Content.ReadFromJsonAsync<WorkSession>(JsonOptions);
+		session.ShouldNotBeNull();
+		session.ClockedInAt.ShouldBe(newClockIn);
+		session.ClockedOutAt.ShouldBe(newClockOut);
+	}
+
+	[Fact]
+	public async Task PutPunch_ClearsTimestamps_WhenNullsProvided()
+	{
+		// Arrange
+		await _client.PostAsJsonAsync(ClockInUrl, new { });
+		var payload = new { ClockedInAt = (DateTime?)null, ClockedOutAt = (DateTime?)null };
+
+		// Act
+		var response = await _client.PutAsJsonAsync(PunchUrl, payload);
+
+		// Assert
+		response.EnsureSuccessStatusCode();
+		var session = await response.Content.ReadFromJsonAsync<WorkSession>(JsonOptions);
+		session.ShouldNotBeNull();
+		session.ClockedInAt.ShouldBeNull();
+		session.ClockedOutAt.ShouldBeNull();
+	}
+
+	[Fact]
+	public async Task PutPunch_Returns422_WhenClockOutSetWithoutClockIn()
+	{
+		// Arrange
+		var payload = new { ClockedInAt = (DateTime?)null, ClockedOutAt = _factory.DateTimeProvider.UtcNow };
+
+		// Act
+		var response = await _client.PutAsJsonAsync(PunchUrl, payload);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task PutPunch_Returns422_WhenClockOutNotAfterClockIn()
+	{
+		// Arrange
+		var clockIn = _factory.DateTimeProvider.UtcNow;
+		var payload = new { ClockedInAt = clockIn, ClockedOutAt = clockIn.AddHours(-1) };
+
+		// Act
+		var response = await _client.PutAsJsonAsync(PunchUrl, payload);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task PutPunch_Returns400_WhenDateMissing()
+	{
+		// Act
+		var response = await _client.PutAsJsonAsync("/api/work-sessions", new { });
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
 	}
 }

--- a/web/src/components/PunchModal.spec.ts
+++ b/web/src/components/PunchModal.spec.ts
@@ -101,7 +101,7 @@ describe('PunchModal', () => {
     endMM.value = '00'
     endMM.dispatchEvent(new Event('input'))
     await nextTick()
-    q('punch-update-btn')!.click()
+    q('punch-save-btn')!.click()
     await nextTick()
 
     // Assert
@@ -126,7 +126,7 @@ describe('PunchModal', () => {
     endHH.value = '09'; endHH.dispatchEvent(new Event('input'))
     endMM.value = '00'; endMM.dispatchEvent(new Event('input'))
     await nextTick()
-    q('punch-update-btn')!.click()
+    q('punch-save-btn')!.click()
     await nextTick()
 
     // Assert
@@ -152,7 +152,7 @@ describe('PunchModal', () => {
     endHH.value = '17'; endHH.dispatchEvent(new Event('input'))
     endMM.value = '30'; endMM.dispatchEvent(new Event('input'))
     await nextTick()
-    q('punch-update-btn')!.click()
+    q('punch-save-btn')!.click()
     await flushPromises()
 
     // Assert
@@ -200,7 +200,7 @@ describe('PunchModal', () => {
     const wrapper = await mountModal(true)
 
     // Act
-    q('punch-cancel-btn')!.click()
+    q('punch-exit-btn')!.click()
     await nextTick()
 
     // Assert

--- a/web/src/components/PunchModal.spec.ts
+++ b/web/src/components/PunchModal.spec.ts
@@ -1,5 +1,5 @@
 import { setActivePinia, createPinia } from 'pinia'
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import type { Mock } from 'vitest'
 
@@ -40,9 +40,12 @@ const sessionClockedIn = {
   createdAt: '2026-05-13T13:00:00Z',
 }
 
+let activeWrapper: VueWrapper | null = null
+
 async function mountModal(isOpen: boolean) {
   const wrapper = mount(PunchModal, { props: { isOpen }, attachTo: document.body })
-  await nextTick()
+  activeWrapper = wrapper
+  await flushPromises()
   return wrapper
 }
 
@@ -53,6 +56,8 @@ describe('PunchModal', () => {
   })
 
   afterEach(() => {
+    activeWrapper?.unmount()
+    activeWrapper = null
     document.body.innerHTML = ''
   })
 

--- a/web/src/components/PunchModal.spec.ts
+++ b/web/src/components/PunchModal.spec.ts
@@ -1,0 +1,209 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import type { Mock } from 'vitest'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import client from '@/api/client'
+import PunchModal from './PunchModal.vue'
+import { useWorkSessionStore } from '@/stores/workSession'
+
+const mockGet = (client as any).get as Mock
+const mockPut = (client as any).put as Mock
+
+// Teleport renders outside the wrapper — query from document.body
+function q(testId: string): HTMLInputElement | null {
+  return document.body.querySelector(`[data-testid="${testId}"]`)
+}
+
+const sessionWithBoth = {
+  id: 1,
+  date: '2026-05-13',
+  clockedInAt: '2026-05-13T13:00:00Z',
+  clockedOutAt: '2026-05-13T21:30:00Z',
+  createdAt: '2026-05-13T13:00:00Z',
+}
+
+const sessionClockedIn = {
+  id: 1,
+  date: '2026-05-13',
+  clockedInAt: '2026-05-13T13:00:00Z',
+  clockedOutAt: null,
+  createdAt: '2026-05-13T13:00:00Z',
+}
+
+async function mountModal(isOpen: boolean) {
+  const wrapper = mount(PunchModal, { props: { isOpen }, attachTo: document.body })
+  await nextTick()
+  return wrapper
+}
+
+describe('PunchModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('PunchModal_PrePopulatesFromSession_WhenOpenWithBothTimes', async () => {
+    // Arrange
+    mockGet.mockResolvedValue(sessionWithBoth)
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    await mountModal(true)
+
+    // Assert — local time extracted from ISO
+    const startIn = new Date(sessionWithBoth.clockedInAt!)
+    const endIn = new Date(sessionWithBoth.clockedOutAt!)
+    expect(q('start-hh')?.value).toBe(String(startIn.getHours()).padStart(2, '0'))
+    expect(q('start-mm')?.value).toBe(String(startIn.getMinutes()).padStart(2, '0'))
+    expect(q('end-hh')?.value).toBe(String(endIn.getHours()).padStart(2, '0'))
+    expect(q('end-mm')?.value).toBe(String(endIn.getMinutes()).padStart(2, '0'))
+  })
+
+  it('PunchModal_ShowsEmptyInputs_WhenNoSession', async () => {
+    // Arrange — 204 No Content unwraps to ''
+    mockGet.mockResolvedValue('')
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    await mountModal(true)
+
+    // Assert
+    expect(q('start-hh')?.value).toBe('')
+    expect(q('start-mm')?.value).toBe('')
+    expect(q('end-hh')?.value).toBe('')
+    expect(q('end-mm')?.value).toBe('')
+  })
+
+  it('PunchModal_ShowsError_WhenEndSetWithoutStart', async () => {
+    // Arrange
+    mockGet.mockResolvedValue('')
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    await mountModal(true)
+
+    // Act — fill end only
+    const endHH = q('end-hh')!
+    const endMM = q('end-mm')!
+    endHH.value = '17'
+    endHH.dispatchEvent(new Event('input'))
+    endMM.value = '00'
+    endMM.dispatchEvent(new Event('input'))
+    await nextTick()
+    q('punch-update-btn')!.click()
+    await nextTick()
+
+    // Assert
+    expect(q('punch-error')?.textContent).toContain('Cannot set end time without a start time')
+    expect(mockPut).not.toHaveBeenCalled()
+  })
+
+  it('PunchModal_ShowsError_WhenEndBeforeStart', async () => {
+    // Arrange
+    mockGet.mockResolvedValue('')
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    await mountModal(true)
+
+    // Act — end before start
+    const startHH = q('start-hh')!
+    const startMM = q('start-mm')!
+    const endHH = q('end-hh')!
+    const endMM = q('end-mm')!
+    startHH.value = '17'; startHH.dispatchEvent(new Event('input'))
+    startMM.value = '00'; startMM.dispatchEvent(new Event('input'))
+    endHH.value = '09'; endHH.dispatchEvent(new Event('input'))
+    endMM.value = '00'; endMM.dispatchEvent(new Event('input'))
+    await nextTick()
+    q('punch-update-btn')!.click()
+    await nextTick()
+
+    // Assert
+    expect(q('punch-error')?.textContent).toContain('End time must be after start time')
+    expect(mockPut).not.toHaveBeenCalled()
+  })
+
+  it('PunchModal_CallsPunch_WhenUpdateClicked', async () => {
+    // Arrange
+    mockGet.mockResolvedValue(sessionClockedIn)
+    mockPut.mockResolvedValue(sessionWithBoth)
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    const wrapper = await mountModal(true)
+
+    // Act — set start and end times
+    const startHH = q('start-hh')!
+    const startMM = q('start-mm')!
+    const endHH = q('end-hh')!
+    const endMM = q('end-mm')!
+    startHH.value = '09'; startHH.dispatchEvent(new Event('input'))
+    startMM.value = '00'; startMM.dispatchEvent(new Event('input'))
+    endHH.value = '17'; endHH.dispatchEvent(new Event('input'))
+    endMM.value = '30'; endMM.dispatchEvent(new Event('input'))
+    await nextTick()
+    q('punch-update-btn')!.click()
+    await flushPromises()
+
+    // Assert
+    expect(mockPut).toHaveBeenCalledOnce()
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('PunchModal_ClearsStartInputs_WhenClearStartClicked', async () => {
+    // Arrange
+    mockGet.mockResolvedValue(sessionClockedIn)
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    await mountModal(true)
+
+    // Act
+    q('clear-start')!.click()
+    await nextTick()
+
+    // Assert
+    expect(q('start-hh')?.value).toBe('')
+    expect(q('start-mm')?.value).toBe('')
+  })
+
+  it('PunchModal_ClearsEndInputs_WhenClearEndClicked', async () => {
+    // Arrange
+    mockGet.mockResolvedValue(sessionWithBoth)
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    await mountModal(true)
+
+    // Act
+    q('clear-end')!.click()
+    await nextTick()
+
+    // Assert
+    expect(q('end-hh')?.value).toBe('')
+    expect(q('end-mm')?.value).toBe('')
+  })
+
+  it('PunchModal_EmitsClose_WhenCancelClicked', async () => {
+    // Arrange
+    mockGet.mockResolvedValue('')
+    const store = useWorkSessionStore()
+    await store.fetchToday()
+    const wrapper = await mountModal(true)
+
+    // Act
+    q('punch-cancel-btn')!.click()
+    await nextTick()
+
+    // Assert
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})

--- a/web/src/components/PunchModal.vue
+++ b/web/src/components/PunchModal.vue
@@ -1,0 +1,255 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { useWorkSessionStore } from '@/stores/workSession'
+import { getToday } from '@/utils/week'
+
+const { isOpen } = defineProps<{
+  isOpen: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const store = useWorkSessionStore()
+
+const startHH = ref('')
+const startMM = ref('')
+const endHH = ref('')
+const endMM = ref('')
+const errorMsg = ref('')
+const startHHRef = ref<HTMLInputElement | null>(null)
+
+function isoToLocalParts(iso: string | null | undefined): { hh: string; mm: string } {
+  if (!iso) return { hh: '', mm: '' }
+  const d = new Date(iso)
+  return {
+    hh: String(d.getHours()).padStart(2, '0'),
+    mm: String(d.getMinutes()).padStart(2, '0'),
+  }
+}
+
+function populate() {
+  const start = isoToLocalParts(store.today?.clockedInAt)
+  const end = isoToLocalParts(store.today?.clockedOutAt)
+  startHH.value = start.hh
+  startMM.value = start.mm
+  endHH.value = end.hh
+  endMM.value = end.mm
+  errorMsg.value = ''
+}
+
+function clearStart() {
+  startHH.value = ''
+  startMM.value = ''
+}
+
+function clearEnd() {
+  endHH.value = ''
+  endMM.value = ''
+}
+
+function buildLocalDate(hhStr: string, mmStr: string): Date {
+  const hh = parseInt(hhStr, 10)
+  const mm = parseInt(mmStr, 10)
+  const [y, mo, d] = getToday().split('-').map(Number)
+  return new Date(y!, mo! - 1, d!, hh, mm, 0, 0)
+}
+
+function validate(): string | null {
+  const sHH = startHH.value.trim()
+  const sMM = startMM.value.trim()
+  const eHH = endHH.value.trim()
+  const eMM = endMM.value.trim()
+
+  const hasStart = sHH !== '' || sMM !== ''
+  const hasEnd = eHH !== '' || eMM !== ''
+
+  if (hasStart && (sHH === '' || sMM === '')) return 'Enter both start hour and minute'
+  if (hasEnd && (eHH === '' || eMM === '')) return 'Enter both end hour and minute'
+
+  if (hasStart) {
+    const h = parseInt(sHH, 10)
+    const m = parseInt(sMM, 10)
+    if (isNaN(h) || h < 0 || h > 23) return 'Start hour must be 00–23'
+    if (isNaN(m) || m < 0 || m > 59) return 'Start minute must be 00–59'
+  }
+
+  if (hasEnd) {
+    if (!hasStart) return 'Cannot set end time without a start time'
+    const sh = parseInt(sHH, 10)
+    const sm = parseInt(sMM, 10)
+    const eh = parseInt(eHH, 10)
+    const em = parseInt(eMM, 10)
+    if (isNaN(eh) || eh < 0 || eh > 23) return 'End hour must be 00–23'
+    if (isNaN(em) || em < 0 || em > 59) return 'End minute must be 00–59'
+    if (eh < sh || (eh === sh && em <= sm)) return 'End time must be after start time'
+  }
+
+  return null
+}
+
+async function handleUpdate() {
+  const err = validate()
+  if (err) {
+    errorMsg.value = err
+    return
+  }
+
+  const sHH = startHH.value.trim()
+  const sMM = startMM.value.trim()
+  const eHH = endHH.value.trim()
+  const eMM = endMM.value.trim()
+
+  const clockedIn = sHH !== '' && sMM !== '' ? buildLocalDate(sHH, sMM) : null
+  const clockedOut = eHH !== '' && eMM !== '' ? buildLocalDate(eHH, eMM) : null
+
+  await store.punch(clockedIn, clockedOut)
+  emit('close')
+}
+
+watch(() => isOpen, (open) => {
+  if (open) {
+    populate()
+    setTimeout(() => startHHRef.value?.focus(), 50)
+  }
+}, { immediate: true })
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (!isOpen) return
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    emit('close')
+  }
+}
+
+onMounted(() => window.addEventListener('keydown', handleKeyDown))
+onUnmounted(() => window.removeEventListener('keydown', handleKeyDown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isOpen"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      data-testid="punch-modal-overlay"
+    >
+      <div class="w-[480px] bg-card border-4 border-double border-primary flex flex-col">
+        <!-- Title bar -->
+        <div class="border-b-4 border-double border-primary px-4 py-2 flex items-center justify-center">
+          <span class="text-primary font-bold tracking-wider" data-testid="punch-modal-title">// PUNCH CLOCK</span>
+        </div>
+
+        <!-- Content -->
+        <div class="p-6 space-y-6">
+          <!-- Start Time -->
+          <div>
+            <div class="text-xs text-muted-foreground mb-2">
+              <span class="text-accent">&gt;&gt;&gt;</span>
+              Start Time
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="text-primary">$</span>
+              <input
+                ref="startHHRef"
+                v-model="startHH"
+                type="text"
+                maxlength="2"
+                placeholder="HH"
+                class="w-12 bg-input border border-border px-2 py-1 text-center text-foreground focus:outline-none focus:border-primary font-mono"
+                data-testid="start-hh"
+              />
+              <span class="text-muted-foreground">:</span>
+              <input
+                v-model="startMM"
+                type="text"
+                maxlength="2"
+                placeholder="mm"
+                class="w-12 bg-input border border-border px-2 py-1 text-center text-foreground focus:outline-none focus:border-primary font-mono"
+                data-testid="start-mm"
+              />
+              <button
+                type="button"
+                class="text-xs text-muted-foreground hover:text-destructive transition-colors ml-2"
+                data-testid="clear-start"
+                @click="clearStart"
+              >
+                [clear]
+              </button>
+            </div>
+          </div>
+
+          <!-- End Time -->
+          <div>
+            <div class="text-xs text-muted-foreground mb-2">
+              <span class="text-accent">&gt;&gt;&gt;</span>
+              End Time
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="text-primary">$</span>
+              <input
+                v-model="endHH"
+                type="text"
+                maxlength="2"
+                placeholder="HH"
+                class="w-12 bg-input border border-border px-2 py-1 text-center text-foreground focus:outline-none focus:border-primary font-mono"
+                data-testid="end-hh"
+              />
+              <span class="text-muted-foreground">:</span>
+              <input
+                v-model="endMM"
+                type="text"
+                maxlength="2"
+                placeholder="mm"
+                class="w-12 bg-input border border-border px-2 py-1 text-center text-foreground focus:outline-none focus:border-primary font-mono"
+                data-testid="end-mm"
+              />
+              <button
+                type="button"
+                class="text-xs text-muted-foreground hover:text-destructive transition-colors ml-2"
+                data-testid="clear-end"
+                @click="clearEnd"
+              >
+                [clear]
+              </button>
+            </div>
+          </div>
+
+          <!-- Error -->
+          <div
+            v-if="errorMsg"
+            class="text-destructive text-xs"
+            data-testid="punch-error"
+          >
+            <span class="text-accent">ERR:</span>
+            {{ errorMsg }}
+          </div>
+        </div>
+
+        <!-- Action bar -->
+        <div class="border-t-4 border-double border-primary px-4 py-3 flex items-center justify-center gap-8">
+          <button
+            type="button"
+            class="hover:text-primary transition-colors"
+            data-testid="punch-update-btn"
+            @click="handleUpdate"
+          >
+            <span class="text-accent">[</span>
+            <span class="text-primary font-bold">Update</span>
+            <span class="text-accent">]</span>
+          </button>
+          <button
+            type="button"
+            class="hover:text-primary transition-colors"
+            data-testid="punch-cancel-btn"
+            @click="$emit('close')"
+          >
+            <span class="text-accent">[</span>
+            <span class="text-muted-foreground">Cancel</span>
+            <span class="text-accent">]</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/web/src/components/PunchModal.vue
+++ b/web/src/components/PunchModal.vue
@@ -89,7 +89,7 @@ function validate(): string | null {
   return null
 }
 
-async function handleUpdate() {
+async function handleSave() {
   const err = validate()
   if (err) {
     errorMsg.value = err
@@ -117,7 +117,22 @@ watch(() => isOpen, (open) => {
 
 function handleKeyDown(e: KeyboardEvent) {
   if (!isOpen) return
+
   if (e.key === 'Escape') {
+    e.preventDefault()
+    emit('close')
+    return
+  }
+
+  const target = e.target as HTMLElement
+  const isInInput = target.tagName === 'INPUT'
+  if (isInInput) return
+
+  const key = e.key.toLowerCase()
+  if (key === 's') {
+    e.preventDefault()
+    handleSave()
+  } else if (key === 'e') {
     e.preventDefault()
     emit('close')
   }
@@ -228,25 +243,28 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeyDown))
 
         <!-- Action bar -->
         <div class="border-t-4 border-double border-primary px-4 py-3 flex items-center justify-center gap-8">
+          <span class="animate-pulse text-accent">_</span>
           <button
             type="button"
             class="hover:text-primary transition-colors"
-            data-testid="punch-update-btn"
-            @click="handleUpdate"
+            data-testid="punch-save-btn"
+            @click="handleSave"
           >
             <span class="text-accent">[</span>
-            <span class="text-primary font-bold">Update</span>
+            <span class="text-primary font-bold">S</span>
             <span class="text-accent">]</span>
+            <span class="text-muted-foreground">ave</span>
           </button>
           <button
             type="button"
             class="hover:text-primary transition-colors"
-            data-testid="punch-cancel-btn"
+            data-testid="punch-exit-btn"
             @click="$emit('close')"
           >
             <span class="text-accent">[</span>
-            <span class="text-muted-foreground">Cancel</span>
+            <span class="text-primary font-bold">E</span>
             <span class="text-accent">]</span>
+            <span class="text-muted-foreground">xit</span>
           </button>
         </div>
       </div>

--- a/web/src/components/PunchModal.vue
+++ b/web/src/components/PunchModal.vue
@@ -56,6 +56,12 @@ function buildLocalDate(hhStr: string, mmStr: string): Date {
   return new Date(y!, mo! - 1, d!, hh, mm, 0, 0)
 }
 
+const DIGITS = /^\d{1,2}$/
+
+function strictInt(val: string): number {
+  return DIGITS.test(val) ? parseInt(val, 10) : NaN
+}
+
 function validate(): string | null {
   const sHH = startHH.value.trim()
   const sMM = startMM.value.trim()
@@ -69,18 +75,18 @@ function validate(): string | null {
   if (hasEnd && (eHH === '' || eMM === '')) return 'Enter both end hour and minute'
 
   if (hasStart) {
-    const h = parseInt(sHH, 10)
-    const m = parseInt(sMM, 10)
+    const h = strictInt(sHH)
+    const m = strictInt(sMM)
     if (isNaN(h) || h < 0 || h > 23) return 'Start hour must be 00–23'
     if (isNaN(m) || m < 0 || m > 59) return 'Start minute must be 00–59'
   }
 
   if (hasEnd) {
     if (!hasStart) return 'Cannot set end time without a start time'
-    const sh = parseInt(sHH, 10)
-    const sm = parseInt(sMM, 10)
-    const eh = parseInt(eHH, 10)
-    const em = parseInt(eMM, 10)
+    const sh = strictInt(sHH)
+    const sm = strictInt(sMM)
+    const eh = strictInt(eHH)
+    const em = strictInt(eMM)
     if (isNaN(eh) || eh < 0 || eh > 23) return 'End hour must be 00–23'
     if (isNaN(em) || em < 0 || em > 59) return 'End minute must be 00–59'
     if (eh < sh || (eh === sh && em <= sm)) return 'End time must be after start time'
@@ -108,8 +114,9 @@ async function handleSave() {
   emit('close')
 }
 
-watch(() => isOpen, (open) => {
+watch(() => isOpen, async (open) => {
   if (open) {
+    await store.fetchToday()
     populate()
     setTimeout(() => startHHRef.value?.focus(), 50)
   }

--- a/web/src/components/SlashCommandMenu.vue
+++ b/web/src/components/SlashCommandMenu.vue
@@ -115,6 +115,15 @@ onUnmounted(() => {
           </button>
 
           <button
+            data-testid="cmd-punch"
+            class="w-full text-left px-2 py-1 hover:bg-secondary/50 transition-colors"
+            @click="handleCommandClick('punch')"
+          >
+            <span class="text-accent">/punch</span>
+            <span class="text-muted-foreground"> - adjust your clock in or out time</span>
+          </button>
+
+          <button
             data-testid="cmd-archive"
             class="w-full text-left px-2 py-1 hover:bg-secondary/50 transition-colors"
             @click="toggleArchive"

--- a/web/src/stores/workSession.spec.ts
+++ b/web/src/stores/workSession.spec.ts
@@ -16,6 +16,7 @@ import { getToday } from '@/utils/week'
 
 const mockGet = (client as any).get as Mock
 const mockPost = (client as any).post as Mock
+const mockPut = (client as any).put as Mock
 
 const sessionFixture = {
   id: 1,
@@ -94,5 +95,43 @@ describe('useWorkSessionStore', () => {
     // Assert
     expect(mockPost).toHaveBeenCalledWith('/api/work-sessions/clock-out', null, { params: { date: getToday() } })
     expect(store.today).toEqual(finished)
+  })
+
+  it('punch_UpdatesToday_WhenSuccessful', async () => {
+    // Arrange
+    const clockedIn = new Date('2026-05-13T13:03:42Z')
+    const clockedOut = new Date('2026-05-13T21:42:11Z')
+    const updated = { ...sessionFixture, clockedOutAt: clockedOut.toISOString() }
+    mockPut.mockResolvedValue(updated)
+    const store = useWorkSessionStore()
+
+    // Act
+    await store.punch(clockedIn, clockedOut)
+
+    // Assert
+    expect(mockPut).toHaveBeenCalledWith(
+      '/api/work-sessions',
+      { clockedInAt: clockedIn.toISOString(), clockedOutAt: clockedOut.toISOString() },
+      { params: { date: getToday() } },
+    )
+    expect(store.today).toEqual(updated)
+  })
+
+  it('punch_SendsNulls_WhenTimesAreNull', async () => {
+    // Arrange
+    const cleared = { ...sessionFixture, clockedInAt: null, clockedOutAt: null }
+    mockPut.mockResolvedValue(cleared)
+    const store = useWorkSessionStore()
+
+    // Act
+    await store.punch(null, null)
+
+    // Assert
+    expect(mockPut).toHaveBeenCalledWith(
+      '/api/work-sessions',
+      { clockedInAt: null, clockedOutAt: null },
+      { params: { date: getToday() } },
+    )
+    expect(store.today).toEqual(cleared)
   })
 })

--- a/web/src/stores/workSession.ts
+++ b/web/src/stores/workSession.ts
@@ -24,5 +24,12 @@ export const useWorkSessionStore = defineStore('workSession', () => {
     today.value = await client.post('/api/work-sessions/clock-out', null, { params: { date: getToday() } }) as any
   }
 
-  return { today, fetchToday, clockIn, clockOut }
+  async function punch(clockedInAt: Date | null, clockedOutAt: Date | null) {
+    today.value = await client.put('/api/work-sessions', {
+      clockedInAt: clockedInAt?.toISOString() ?? null,
+      clockedOutAt: clockedOutAt?.toISOString() ?? null,
+    }, { params: { date: getToday() } }) as any
+  }
+
+  return { today, fetchToday, clockIn, clockOut, punch }
 })

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -8,7 +8,7 @@ export interface WorkItem {
   weekOf: string
 }
 
-export type CommandType = 'standup' | 'weekly' | 'evaluate-my-week'
+export type CommandType = 'standup' | 'weekly' | 'evaluate-my-week' | 'punch'
 
 export interface ReadWatchItem {
   id: number

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -17,6 +17,7 @@ import ClockStatus from '@/components/ClockStatus.vue'
 import SlashCommandMenu from '@/components/SlashCommandMenu.vue'
 import CommandModal from '@/components/CommandModal.vue'
 import EvaluateWeekModal from '@/components/EvaluateWeekModal.vue'
+import PunchModal from '@/components/PunchModal.vue'
 import PastWeekView from '@/components/PastWeekView.vue'
 
 type ViewMode = 'daily' | 'weekly'
@@ -153,7 +154,7 @@ onMounted(() => {
       <BigThing v-if="!isPastWeek" />
 
       <CommandModal
-        :is-open="activeCommand !== null && activeCommand !== 'evaluate-my-week'"
+        :is-open="activeCommand === 'standup' || activeCommand === 'weekly'"
         :title="modalTitle"
         :command-type="activeCommand"
         :week-of="dailyTasks.weekOf"
@@ -162,6 +163,11 @@ onMounted(() => {
 
       <EvaluateWeekModal
         :is-open="activeCommand === 'evaluate-my-week'"
+        @close="activeCommand = null"
+      />
+
+      <PunchModal
+        :is-open="activeCommand === 'punch'"
         @close="activeCommand = null"
       />
 


### PR DESCRIPTION
## Summary
- Add PUT `/api/work-sessions` endpoint to set or clear clock-in/clock-out timestamps, with validation (no clock-out without clock-in, clock-out must be after clock-in)
- Add `PunchModal` component with HH:mm time inputs, pre-populated from the current session, with clear buttons and keyboard shortcuts (S to save, E to exit)
- Wire `/punch` into the slash command menu and `DailyBoard` view, and add `punch()` action to the work session Pinia store

## Test plan
- [x] API: 6 new xUnit integration tests (`PutPunch_CreatesSession`, `UpdatesExistingSession`, `ClearsTimestamps`, `Returns422_WhenClockOutSetWithoutClockIn`, `Returns422_WhenClockOutNotAfterClockIn`, `Returns400_WhenDateMissing`)
- [x] Frontend: 7 Vitest specs for `PunchModal` (pre-population, empty state, validation errors, save call, clear buttons, cancel)
- [x] Frontend: 2 Vitest specs for `workSession.punch()` store action (update and null clearing)
- [ ] Manual: open the app, type `/punch`, verify modal opens with current session times, adjust times, save, confirm clock status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)