### PR TITLE
feat(api,web): add clock-in ceremony modal with carryover triage

### DIFF
--- a/api/src/Dtos/WorkItemDtos.cs
+++ b/api/src/Dtos/WorkItemDtos.cs
@@ -7,3 +7,5 @@ internal record UpdateWorkItemDto
 	public string? Title { get; init; }
 	public bool? IsDone { get; init; }
 }
+
+internal record MoveWorkItemDto(DateOnly Date);

--- a/api/src/Endpoints/WorkItemEndpoints.cs
+++ b/api/src/Endpoints/WorkItemEndpoints.cs
@@ -55,6 +55,7 @@ internal static class WorkItemEndpoints
 				Date = date,
 				WeekOf = weekOf,
 				SortOrder = sortOrder,
+				OriginalDate = date,
 			};
 			db.WorkItems.Add(item);
 			await db.SaveChangesAsync();
@@ -141,6 +142,35 @@ internal static class WorkItemEndpoints
 			db.WorkItems.Remove(item);
 			await db.SaveChangesAsync();
 			return Results.NoContent();
+		});
+
+		group.MapPatch("/{id}/move", async (AppDbContext db, int id, MoveWorkItemDto dto) =>
+		{
+			var item = await db.WorkItems.FindAsync(id);
+			if (item is null) return Results.NotFound();
+
+			if (item.Category == WorkItemCategory.SmallThing)
+			{
+				var count = await db.WorkItems.CountAsync(w =>
+					w.Date == dto.Date && w.Category == WorkItemCategory.SmallThing && w.Id != item.Id);
+				if (count >= 5)
+					return Results.Problem("Target day is full (5 SmallThings).", statusCode: 422);
+			}
+
+			item.Date = dto.Date;
+			item.WeekOf = ComputeWeekOf(dto.Date);
+			item.TimesMoved += 1;
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
+		});
+
+		group.MapPatch("/{id}/skip", async (AppDbContext db, int id) =>
+		{
+			var item = await db.WorkItems.FindAsync(id);
+			if (item is null) return Results.NotFound();
+			item.IsSkipped = true;
+			await db.SaveChangesAsync();
+			return Results.Ok(item);
 		});
 
 		return group;

--- a/api/src/Endpoints/WorkItemEndpoints.cs
+++ b/api/src/Endpoints/WorkItemEndpoints.cs
@@ -149,6 +149,9 @@ internal static class WorkItemEndpoints
 			var item = await db.WorkItems.FindAsync(id);
 			if (item is null) return Results.NotFound();
 
+			if (dto.Date == default)
+				return Results.Problem("date is required.", statusCode: 400);
+
 			if (item.Category == WorkItemCategory.SmallThing)
 			{
 				var count = await db.WorkItems.CountAsync(w =>

--- a/api/src/Endpoints/WorkItemEndpoints.cs
+++ b/api/src/Endpoints/WorkItemEndpoints.cs
@@ -152,12 +152,17 @@ internal static class WorkItemEndpoints
 			if (dto.Date == default)
 				return Results.Problem("date is required.", statusCode: 400);
 
+			if (item.Date == dto.Date)
+				return Results.Ok(item);
+
 			if (item.Category == WorkItemCategory.SmallThing)
 			{
-				var count = await db.WorkItems.CountAsync(w =>
-					w.Date == dto.Date && w.Category == WorkItemCategory.SmallThing && w.Id != item.Id);
-				if (count >= 5)
+				var existing = await db.WorkItems
+					.Where(w => w.Date == dto.Date && w.Category == WorkItemCategory.SmallThing)
+					.ToListAsync();
+				if (existing.Count >= 5)
 					return Results.Problem("Target day is full (5 SmallThings).", statusCode: 422);
+				item.SortOrder = existing.Count == 0 ? 1 : existing.Max(w => w.SortOrder) + 1;
 			}
 
 			item.Date = dto.Date;

--- a/api/src/Entities/WorkItem.cs
+++ b/api/src/Entities/WorkItem.cs
@@ -11,5 +11,8 @@ internal class WorkItem
 	public int SortOrder { get; set; }
 	public DateOnly Date { get; set; }
 	public required string WeekOf { get; set; }
+	public DateOnly OriginalDate { get; set; }
+	public int TimesMoved { get; set; }
+	public bool IsSkipped { get; set; }
 	public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/api/src/Migrations/20260605144155_AddCarryoverMetadataToWorkItems.Designer.cs
+++ b/api/src/Migrations/20260605144155_AddCarryoverMetadataToWorkItems.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyWork.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DailyWork.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605144155_AddCarryoverMetadataToWorkItems")]
+    partial class AddCarryoverMetadataToWorkItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/src/Migrations/20260605144155_AddCarryoverMetadataToWorkItems.cs
+++ b/api/src/Migrations/20260605144155_AddCarryoverMetadataToWorkItems.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyWork.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCarryoverMetadataToWorkItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSkipped",
+                table: "WorkItems",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "OriginalDate",
+                table: "WorkItems",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1));
+
+            migrationBuilder.AddColumn<int>(
+                name: "TimesMoved",
+                table: "WorkItems",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql("UPDATE \"WorkItems\" SET \"OriginalDate\" = \"Date\"");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSkipped",
+                table: "WorkItems");
+
+            migrationBuilder.DropColumn(
+                name: "OriginalDate",
+                table: "WorkItems");
+
+            migrationBuilder.DropColumn(
+                name: "TimesMoved",
+                table: "WorkItems");
+        }
+    }
+}

--- a/api/tests/WorkItemEndpointTests.cs
+++ b/api/tests/WorkItemEndpointTests.cs
@@ -227,4 +227,104 @@ public class WorkItemEndpointTests : IClassFixture<CustomWebApplicationFactory>,
 		moved.ShouldNotBeNull();
 		moved.SortOrder.ShouldBe(originalSortOrder);
 	}
+
+	[Fact]
+	public async Task PostWorkItem_SetsOriginalDateToDate_WhenCreated()
+	{
+		var date = new DateOnly(2020, 1, 13);
+		var payload = new { Title = "OriginalDate test", Category = "SmallThing", Date = date.ToString("O", System.Globalization.CultureInfo.InvariantCulture) };
+
+		var response = await _client.PostAsJsonAsync("/api/work-items", payload);
+
+		response.StatusCode.ShouldBe(HttpStatusCode.Created);
+		var item = await response.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		item.ShouldNotBeNull();
+		item.OriginalDate.ShouldBe(date);
+	}
+
+	[Fact]
+	public async Task PatchMove_UpdatesDateAndIncrementsTimesMoved_WhenValid()
+	{
+		var sourceDate = new DateOnly(2020, 1, 13);
+		var targetDate = new DateOnly(2020, 1, 14);
+		var r = await _client.PostAsJsonAsync("/api/work-items", new { Title = "Move valid test", Category = "SmallThing", Date = sourceDate.ToString("O", System.Globalization.CultureInfo.InvariantCulture) });
+		var item = await r.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		item.ShouldNotBeNull();
+
+		var response = await _client.PatchAsJsonAsync($"/api/work-items/{item.Id}/move", new { Date = "2020-01-14" });
+
+		response.EnsureSuccessStatusCode();
+		var moved = await response.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		moved.ShouldNotBeNull();
+		moved.Date.ShouldBe(targetDate);
+		moved.TimesMoved.ShouldBe(1);
+	}
+
+	[Fact]
+	public async Task PatchMove_Returns422_WhenTargetDayHasFiveSmallThings()
+	{
+		var targetDate = "2020-01-14";
+		var sourceDate = "2020-01-13";
+
+		for (var i = 0; i < 5; i++)
+			await _client.PostAsJsonAsync("/api/work-items", new { Title = $"Full day {i}", Category = "SmallThing", Date = targetDate });
+
+		var r = await _client.PostAsJsonAsync("/api/work-items", new { Title = "To be moved", Category = "SmallThing", Date = sourceDate });
+		var item = await r.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		item.ShouldNotBeNull();
+
+		var response = await _client.PatchAsJsonAsync($"/api/work-items/{item.Id}/move", new { Date = targetDate });
+
+		response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task PatchMove_Returns404_WhenItemMissing()
+	{
+		var response = await _client.PatchAsJsonAsync("/api/work-items/99999/move", new { Date = "2020-01-14" });
+
+		response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+	}
+
+	[Fact]
+	public async Task PatchMove_RecomputesWeekOf_WhenCrossingWeekBoundary()
+	{
+		// 2020-01-17 is Friday (weekOf 2020-01-13); moving to 2020-01-20 (Monday, weekOf 2020-01-20)
+		var r = await _client.PostAsJsonAsync("/api/work-items", new { Title = "Week boundary move", Category = "SmallThing", Date = "2020-01-17" });
+		var item = await r.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		item.ShouldNotBeNull();
+		item.WeekOf.ShouldBe("2020-01-13");
+
+		var response = await _client.PatchAsJsonAsync($"/api/work-items/{item.Id}/move", new { Date = "2020-01-20" });
+
+		response.EnsureSuccessStatusCode();
+		var moved = await response.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		moved.ShouldNotBeNull();
+		moved.Date.ShouldBe(new DateOnly(2020, 1, 20));
+		moved.WeekOf.ShouldBe("2020-01-20");
+	}
+
+	[Fact]
+	public async Task PatchSkip_SetsIsSkipped_WhenItemExists()
+	{
+		var r = await _client.PostAsJsonAsync("/api/work-items", new { Title = "Skip test", Category = "SmallThing", Date = "2020-01-13" });
+		var item = await r.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		item.ShouldNotBeNull();
+		item.IsSkipped.ShouldBeFalse();
+
+		var response = await _client.PatchAsync($"/api/work-items/{item.Id}/skip", null);
+
+		response.EnsureSuccessStatusCode();
+		var skipped = await response.Content.ReadFromJsonAsync<WorkItem>(JsonOptions);
+		skipped.ShouldNotBeNull();
+		skipped.IsSkipped.ShouldBeTrue();
+	}
+
+	[Fact]
+	public async Task PatchSkip_Returns404_WhenItemMissing()
+	{
+		var response = await _client.PatchAsync("/api/work-items/99999/skip", null);
+
+		response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+	}
 }

--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -6,7 +6,7 @@ import globals from 'globals';
 
 export default tseslint.config(
   {
-    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.config.ts', '*.config.js'],
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.config.ts', '*.config.js', '**/*[Ss]pike*', '**/spike-screenshot.mjs'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/web/src/components/ClockCeremonyModal.spec.ts
+++ b/web/src/components/ClockCeremonyModal.spec.ts
@@ -95,6 +95,18 @@ describe('ClockCeremonyModal', () => {
     expect(q('ceremony-header')?.textContent).toContain('clock-out.ceremony')
   })
 
+  it('ClockCeremonyModal_RendersPunchCardIdle_WhenOpened', async () => {
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(q('punch-card')).not.toBeNull()
+    expect(q('scan-beam')).toBeNull()
+    expect(q('slot-label')?.textContent).toContain('insert card')
+  })
+
   it('ClockCeremonyModal_EmitsClose_WhenExitButtonClicked', async () => {
     const wrapper = mount(ClockCeremonyModal, {
       props: { isOpen: true, mode: 'in' },
@@ -139,7 +151,7 @@ describe('ClockCeremonyModal', () => {
       null,
       { params: { date: '2026-04-08' } }
     )
-    vi.runAllTimers()
+    await vi.runAllTimersAsync()
     vi.useRealTimers()
   })
 
@@ -155,8 +167,7 @@ describe('ClockCeremonyModal', () => {
 
     q('submit-btn')?.click()
     await flushPromises()
-    vi.runAllTimers()
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(wrapper.emitted('close')).toBeTruthy()
     vi.useRealTimers()

--- a/web/src/components/ClockCeremonyModal.spec.ts
+++ b/web/src/components/ClockCeremonyModal.spec.ts
@@ -1,0 +1,214 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { nextTick } from 'vue'
+import type { Mock } from 'vitest'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('@/utils/week', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/week')>()
+  return { ...actual, getToday: vi.fn(), getPreviousWorkday: vi.fn() }
+})
+
+import client from '@/api/client'
+import { getToday, getPreviousWorkday } from '@/utils/week'
+import ClockCeremonyModal from './ClockCeremonyModal.vue'
+import type { WorkSession } from '@/types'
+
+const mockGet = (client as any).get as Mock
+const mockPost = (client as any).post as Mock
+const mockGetToday = getToday as Mock
+const mockGetPreviousWorkday = getPreviousWorkday as Mock
+
+// Teleport renders outside the wrapper — query from document.body
+function q(testId: string): HTMLElement | null {
+  return document.body.querySelector(`[data-testid="${testId}"]`)
+}
+
+const createMockSession = (overrides: Partial<WorkSession> = {}): WorkSession => ({
+  id: 1,
+  date: '2026-04-08',
+  clockedInAt: null,
+  clockedOutAt: null,
+  createdAt: '2026-04-08T00:00:00Z',
+  ...overrides,
+})
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  mockGetToday.mockReturnValue('2026-04-08')
+  mockGetPreviousWorkday.mockReturnValue('2026-04-07')
+  mockGet.mockResolvedValue([])
+})
+
+afterEach(() => {
+  // Clean up any leftover teleport content
+  document.body.innerHTML = ''
+})
+
+describe('ClockCeremonyModal', () => {
+  it('ClockCeremonyModal_IsNotRendered_WhenIsOpenFalse', () => {
+    mount(ClockCeremonyModal, {
+      props: { isOpen: false, mode: 'in' },
+      attachTo: document.body,
+    })
+
+    expect(q('ceremony-modal')).toBeNull()
+  })
+
+  it('ClockCeremonyModal_IsRendered_WhenIsOpenTrue', async () => {
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(q('ceremony-modal')).not.toBeNull()
+  })
+
+  it('ClockCeremonyModal_ShowsClockInHeader_WhenModeIsIn', async () => {
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(q('ceremony-header')?.textContent).toContain('clock-in.ceremony')
+  })
+
+  it('ClockCeremonyModal_ShowsClockOutHeader_WhenModeIsOut', async () => {
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'out' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(q('ceremony-header')?.textContent).toContain('clock-out.ceremony')
+  })
+
+  it('ClockCeremonyModal_EmitsClose_WhenExitButtonClicked', async () => {
+    const wrapper = mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    q('exit-btn')?.click()
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('ClockCeremonyModal_EmitsClose_WhenEscapePressed', async () => {
+    const wrapper = mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('ClockCeremonyModal_ClocksIn_WhenSubmitButtonClicked', async () => {
+    mockPost.mockResolvedValue(createMockSession({ clockedInAt: '2026-04-08T09:00:00Z' }))
+    vi.useFakeTimers()
+
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    q('submit-btn')?.click()
+    await flushPromises()
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/work-sessions/clock-in',
+      null,
+      { params: { date: '2026-04-08' } }
+    )
+    vi.useRealTimers()
+  })
+
+  it('ClockCeremonyModal_EmitsClose_AfterSuccessfulClockIn', async () => {
+    mockPost.mockResolvedValue(createMockSession({ clockedInAt: '2026-04-08T09:00:00Z' }))
+    vi.useFakeTimers()
+
+    const wrapper = mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    q('submit-btn')?.click()
+    await flushPromises()
+    vi.runAllTimers()
+    await flushPromises()
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+    vi.useRealTimers()
+  })
+
+  it('ClockCeremonyModal_ShowsTerminalError_WhenClockInFails', async () => {
+    const error = Object.assign(new Error('500'), { response: { status: 500 } })
+    mockPost.mockRejectedValue(error)
+
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    q('submit-btn')?.click()
+    await flushPromises()
+
+    expect(q('terminal-error')).not.toBeNull()
+    expect(q('terminal-error')?.textContent).toContain('clock-in failed: HTTP 500')
+  })
+
+  it('ClockCeremonyModal_ReEnablesSubmit_AfterFailure', async () => {
+    const error = Object.assign(new Error('503'), { response: { status: 503 } })
+    mockPost.mockRejectedValue(error)
+
+    mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    q('submit-btn')?.click()
+    await flushPromises()
+
+    const btn = q('submit-btn') as HTMLButtonElement | null
+    expect(btn?.disabled).toBe(false)
+  })
+
+  it('ClockCeremonyModal_DoesNotEmitClose_WhenExitClickedWhileBusy', async () => {
+    mockPost.mockReturnValue(new Promise(() => {}))
+
+    const wrapper = mount(ClockCeremonyModal, {
+      props: { isOpen: true, mode: 'in' },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    q('submit-btn')?.click()
+    await nextTick()
+    q('exit-btn')?.click()
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toBeFalsy()
+  })
+})

--- a/web/src/components/ClockCeremonyModal.spec.ts
+++ b/web/src/components/ClockCeremonyModal.spec.ts
@@ -139,6 +139,7 @@ describe('ClockCeremonyModal', () => {
       null,
       { params: { date: '2026-04-08' } }
     )
+    vi.runAllTimers()
     vi.useRealTimers()
   })
 

--- a/web/src/components/ClockCeremonyModal.spec.ts
+++ b/web/src/components/ClockCeremonyModal.spec.ts
@@ -1,7 +1,11 @@
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import { nextTick } from 'vue'
 import type { Mock } from 'vitest'
+
+// The modal registers a global window keydown listener on mount —
+// unmount wrappers after each test so listeners don't leak across tests
+enableAutoUnmount(afterEach)
 
 vi.mock('@/api/client', () => ({
   default: {

--- a/web/src/components/ClockCeremonyModal.vue
+++ b/web/src/components/ClockCeremonyModal.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import type { AxiosError } from 'axios'
+import { useWorkSessionStore } from '@/stores/workSession'
+import { useDailyTasksStore } from '@/stores/dailyTasks'
+import ClockInTriage from '@/components/ClockInTriage.vue'
+import { getToday, getPreviousWorkday } from '@/utils/week'
+
+const EMPLOYEE_NAME = 'Jared Bacik'
+const EMPLOYEE_ID = '20210628'
+const COMPANY = 'VIRTUOUS'
+
+const { isOpen, mode } = defineProps<{
+  isOpen: boolean
+  mode: 'in' | 'out'
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const workSessionStore = useWorkSessionStore()
+const dailyTasksStore = useDailyTasksStore()
+
+const busy = ref(false)
+const terminalError = ref('')
+const animState = ref<'idle' | 'running' | 'done' | 'failed'>('idle')
+
+const today = getToday()
+
+const todayLabel = today
+
+const previousWorkday = getPreviousWorkday()
+
+const triageItems = computed(() => {
+  if (!previousWorkday) return []
+  return dailyTasksStore.items.filter(t =>
+    t.category === 'SmallThing' &&
+    t.date === previousWorkday &&
+    !t.isDone &&
+    !t.isSkipped
+  )
+})
+
+const slotLabel = computed(() => {
+  if (animState.value === 'running') return 'scanning...'
+  if (animState.value === 'done') return '✓ punched'
+  return 'insert card'
+})
+
+async function runAnimation() {
+  animState.value = 'running'
+}
+
+async function finishAnimation() {
+  animState.value = 'done'
+  await new Promise<void>(r => setTimeout(r, 600))
+}
+
+function cancelAnimation() {
+  animState.value = 'failed'
+  setTimeout(() => { animState.value = 'idle' }, 250)
+}
+
+async function handleSubmit() {
+  if (busy.value) return
+  busy.value = true
+  terminalError.value = ''
+  runAnimation()
+  try {
+    if (mode === 'in') {
+      await workSessionStore.clockIn()
+    }
+    await finishAnimation()
+    emit('close')
+  } catch (e) {
+    cancelAnimation()
+    const status = (e as AxiosError).response?.status ?? '?'
+    terminalError.value = `! clock-${mode} failed: HTTP ${status}`
+    busy.value = false
+  }
+}
+
+function handleClose() {
+  if (busy.value) return
+  emit('close')
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (!isOpen) return
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    handleClose()
+    return
+  }
+  const target = e.target as HTMLElement
+  if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return
+  const key = e.key.toLowerCase()
+  if (key === 'c') {
+    e.preventDefault()
+    handleSubmit()
+  } else if (key === 'e') {
+    e.preventDefault()
+    handleClose()
+  }
+}
+
+watch(() => isOpen, async (open) => {
+  if (open) {
+    terminalError.value = ''
+    animState.value = 'idle'
+    busy.value = false
+    await dailyTasksStore.fetch()
+  }
+}, { immediate: true })
+
+onMounted(() => window.addEventListener('keydown', handleKeyDown))
+onUnmounted(() => window.removeEventListener('keydown', handleKeyDown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isOpen"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      data-testid="ceremony-overlay"
+      @click.self="handleClose"
+    >
+      <div
+        class="w-[60vw] max-h-[80vh] bg-card border-4 border-double border-primary flex flex-col"
+        data-testid="ceremony-modal"
+      >
+        <!-- Header -->
+        <div class="border-b-4 border-double border-primary px-4 py-2 flex items-center justify-center">
+          <span class="text-primary font-bold tracking-wider text-xs uppercase" data-testid="ceremony-header">
+            // clock-{{ mode }}.ceremony · {{ todayLabel }}
+          </span>
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 bg-background px-8 py-7 flex flex-col gap-6 overflow-y-auto">
+          <!-- Punch card slot -->
+          <div class="flex flex-col" data-testid="punch-card-slot">
+            <div class="h-3 opacity-35" style="background: repeating-linear-gradient(90deg, var(--color-muted-foreground) 0px, var(--color-muted-foreground) 2px, transparent 2px, transparent 6px);"></div>
+            <div class="h-10 flex items-center px-3.5 bg-card border-y border-border">
+              <span
+                class="text-muted-foreground text-xs uppercase tracking-widest"
+                :class="{ 'animate-pulse': animState === 'running' }"
+                data-testid="slot-label"
+              >
+                {{ slotLabel }}
+              </span>
+              <span class="flex-1" />
+              <span class="text-muted-foreground text-xs tracking-widest">{{ EMPLOYEE_NAME }} · {{ EMPLOYEE_ID }} · {{ COMPANY }}</span>
+            </div>
+            <div class="h-3 opacity-35" style="background: repeating-linear-gradient(90deg, var(--color-muted-foreground) 0px, var(--color-muted-foreground) 2px, transparent 2px, transparent 6px);"></div>
+          </div>
+
+          <!-- Triage (clock-in mode) -->
+          <ClockInTriage
+            v-if="mode === 'in'"
+            :items="triageItems"
+          />
+
+          <!-- Terminal error -->
+          <div
+            v-if="terminalError"
+            class="text-destructive text-xs font-mono"
+            data-testid="terminal-error"
+          >
+            {{ terminalError }}
+          </div>
+        </div>
+
+        <!-- Footer action bar -->
+        <div class="border-t-4 border-double border-primary px-4 py-3 flex items-center justify-center gap-8">
+          <span class="animate-pulse text-accent">_</span>
+          <button
+            type="button"
+            class="font-mono text-sm hover:opacity-75 transition-opacity disabled:opacity-40"
+            :disabled="busy"
+            data-testid="submit-btn"
+            @click="handleSubmit"
+          >
+            <span class="text-accent">[</span>
+            <span class="text-primary font-bold">C</span>
+            <span class="text-accent">]</span>
+            <span class="text-muted-foreground">lock {{ mode === 'in' ? 'In' : 'Out' }}</span>
+          </button>
+          <button
+            type="button"
+            class="font-mono text-sm hover:opacity-75 transition-opacity"
+            data-testid="exit-btn"
+            @click="handleClose"
+          >
+            <span class="text-accent">[</span>
+            <span class="text-primary font-bold">E</span>
+            <span class="text-accent">]</span>
+            <span class="text-muted-foreground">xit</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/web/src/components/ClockCeremonyModal.vue
+++ b/web/src/components/ClockCeremonyModal.vue
@@ -25,6 +25,17 @@ const dailyTasksStore = useDailyTasksStore()
 const busy = ref(false)
 const terminalError = ref('')
 const animState = ref<'idle' | 'running' | 'done' | 'failed'>('idle')
+const cardState = ref<'' | 'inserting' | 'ejecting' | 'cancelling'>('')
+const scanning = ref(false)
+const scanPass = ref(0)
+const litUpTo = ref(-1)
+const isFlashing = ref(false)
+// Bumped to abort any in-flight animation sequence (retry, cancel, reopen)
+let animToken = 0
+let runPromise: Promise<void> | null = null
+
+const HOLE_PATTERN = [1,0,1,0,0,1,1,0,1,0,0,1,1,0,1,0,0,1,1,0,1,0,0,1,
+                      1,0,1,0,0,1,1,0,1,0,0,1,1,0,1,0,0,1,1,0,1,0,0,1]
 
 const today = getToday()
 
@@ -43,30 +54,88 @@ const triageItems = computed(() => {
 })
 
 const slotLabel = computed(() => {
-  if (animState.value === 'running') return 'scanning...'
+  // While running/failed the card occupies the slot — no label
+  if (animState.value === 'running' || animState.value === 'failed') return ''
   if (animState.value === 'done') return '✓ punched'
   return 'insert card'
 })
 
-function runAnimation() {
+const employeeNameFormatted = computed(() => {
+  const parts = EMPLOYEE_NAME.trim().split(' ')
+  const last = parts.pop()!.toUpperCase()
+  const first = parts.join(' ').toUpperCase()
+  return `${last}, ${first} · ${COMPANY}`
+})
+
+const cardStyle = computed(() => {
+  switch (cardState.value) {
+    case 'inserting':
+      return { transform: 'translateY(-50%) translateX(0)', transition: 'transform 0.65s cubic-bezier(0.3, 0, 0.2, 1)' }
+    case 'ejecting':
+      return { transform: 'translateY(-50%) translateX(-120vw)', transition: 'transform 0.45s cubic-bezier(0.6, 0, 1, 0.4)' }
+    case 'cancelling':
+      // Decision 20: ~250ms ease-out, card returns to slot
+      return { transform: 'translateY(-50%) translateX(120vw)', transition: 'transform 0.25s ease-out' }
+    default:
+      return { transform: 'translateY(-50%) translateX(120vw)', transition: 'none' }
+  }
+})
+
+const wait = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
+
+async function runAnimation() {
+  const token = ++animToken
   animState.value = 'running'
+  cardState.value = ''
+  litUpTo.value = -1
+  await wait(40)
+  if (token !== animToken) return
+  cardState.value = 'inserting'
+  await wait(680)
+  if (token !== animToken) return
+  scanning.value = true
+  for (let pass = 0; pass < 3; pass++) {
+    scanPass.value++
+    litUpTo.value = Math.floor((pass / 2) * HOLE_PATTERN.length)
+    await wait(200)
+    if (token !== animToken) return
+  }
+  scanning.value = false
+  litUpTo.value = -1
 }
 
 async function finishAnimation() {
+  // Optimistic timing (decision 12): save resolved while the card was
+  // inserting/scanning — let the run sequence complete before ejecting
+  if (runPromise) await runPromise
+  animToken++
+  scanning.value = false
+  litUpTo.value = -1
   animState.value = 'done'
-  await new Promise<void>(r => setTimeout(r, 600))
+  cardState.value = 'ejecting'
+  await wait(480)
+  isFlashing.value = true
+  await wait(220)
 }
 
 function cancelAnimation() {
+  animToken++
+  scanning.value = false
+  litUpTo.value = -1
   animState.value = 'failed'
-  setTimeout(() => { animState.value = 'idle' }, 250)
+  cardState.value = 'cancelling'
+  setTimeout(() => {
+    animState.value = 'idle'
+    cardState.value = ''
+  }, 250)
 }
 
 async function handleSubmit() {
   if (busy.value) return
   busy.value = true
   terminalError.value = ''
-  runAnimation()
+  isFlashing.value = false
+  runPromise = runAnimation()
   try {
     if (mode === 'in') {
       await workSessionStore.clockIn()
@@ -109,8 +178,13 @@ function handleKeyDown(e: KeyboardEvent) {
 
 watch(() => isOpen, async (open) => {
   if (open) {
+    animToken++
     terminalError.value = ''
     animState.value = 'idle'
+    cardState.value = ''
+    scanning.value = false
+    litUpTo.value = -1
+    isFlashing.value = false
     busy.value = false
     await dailyTasksStore.fetch()
   }
@@ -140,20 +214,56 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeyDown))
         </div>
 
         <!-- Body -->
-        <div class="flex-1 bg-background px-8 py-7 flex flex-col gap-6 overflow-y-auto">
+        <div
+          class="flex-1 bg-background px-8 py-7 flex flex-col gap-6 overflow-y-auto"
+          :class="{ 'animate-success-flash': isFlashing }"
+        >
           <!-- Punch card slot -->
           <div class="flex flex-col" data-testid="punch-card-slot">
             <div class="h-3 opacity-35" style="background: repeating-linear-gradient(90deg, var(--color-muted-foreground) 0px, var(--color-muted-foreground) 2px, transparent 2px, transparent 6px);"></div>
-            <div class="h-10 flex items-center px-3.5 bg-card border-y border-border">
-              <span
-                class="text-muted-foreground text-xs uppercase tracking-widest"
-                :class="{ 'animate-pulse': animState === 'running' }"
-                data-testid="slot-label"
-              >
+            <div class="relative h-12 flex items-center px-3.5 bg-card border-y border-border overflow-hidden">
+              <span class="text-muted-foreground text-xs uppercase tracking-widest" data-testid="slot-label">
                 {{ slotLabel }}
               </span>
               <span class="flex-1" />
               <span class="text-muted-foreground text-xs tracking-widest">{{ EMPLOYEE_NAME }} · {{ EMPLOYEE_ID }} · {{ COMPANY }}</span>
+
+              <!-- Scan beam -->
+              <div
+                v-if="scanning"
+                :key="scanPass"
+                class="absolute inset-y-0 w-[3px] bg-accent z-30 animate-scan-sweep"
+                data-testid="scan-beam"
+              ></div>
+
+              <!-- Punch card -->
+              <div class="absolute inset-0 pointer-events-none z-20">
+                <div
+                  class="absolute top-1/2 left-[60px] w-[420px] h-10 bg-card border border-border flex items-stretch overflow-hidden"
+                  :style="cardStyle"
+                  data-testid="punch-card"
+                >
+                  <div class="w-2.5 bg-background border-r border-border shrink-0"></div>
+                  <div class="flex flex-col justify-between px-2 py-[3px] flex-1 overflow-hidden">
+                    <div class="text-[9px] tracking-wider text-accent whitespace-nowrap">
+                      EMP-ID: {{ EMPLOYEE_ID }} · {{ COMPANY }} · 2026
+                    </div>
+                    <div class="flex gap-[3px] items-center">
+                      <div
+                        v-for="(punched, i) in HOLE_PATTERN"
+                        :key="i"
+                        class="w-[5px] h-2 border shrink-0 transition-colors"
+                        :class="punched
+                          ? (litUpTo >= i ? 'bg-accent border-accent' : 'bg-foreground border-foreground')
+                          : 'bg-transparent border-border'"
+                      ></div>
+                    </div>
+                    <div class="text-[9px] text-muted-foreground whitespace-nowrap tracking-wide">
+                      {{ employeeNameFormatted }}
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
             <div class="h-3 opacity-35" style="background: repeating-linear-gradient(90deg, var(--color-muted-foreground) 0px, var(--color-muted-foreground) 2px, transparent 2px, transparent 6px);"></div>
           </div>

--- a/web/src/components/ClockCeremonyModal.vue
+++ b/web/src/components/ClockCeremonyModal.vue
@@ -70,6 +70,8 @@ async function handleSubmit() {
   try {
     if (mode === 'in') {
       await workSessionStore.clockIn()
+    } else {
+      await workSessionStore.clockOut()
     }
     await finishAnimation()
     emit('close')

--- a/web/src/components/ClockCeremonyModal.vue
+++ b/web/src/components/ClockCeremonyModal.vue
@@ -119,12 +119,14 @@ async function finishAnimation() {
 }
 
 function cancelAnimation() {
-  animToken++
+  const token = ++animToken
   scanning.value = false
   litUpTo.value = -1
   animState.value = 'failed'
   cardState.value = 'cancelling'
   setTimeout(() => {
+    // A resubmit within the 250ms ease-out owns the animation now
+    if (token !== animToken) return
     animState.value = 'idle'
     cardState.value = ''
   }, 250)

--- a/web/src/components/ClockCeremonyModal.vue
+++ b/web/src/components/ClockCeremonyModal.vue
@@ -48,7 +48,7 @@ const slotLabel = computed(() => {
   return 'insert card'
 })
 
-async function runAnimation() {
+function runAnimation() {
   animState.value = 'running'
 }
 

--- a/web/src/components/ClockInTriage.spec.ts
+++ b/web/src/components/ClockInTriage.spec.ts
@@ -142,4 +142,21 @@ describe('ClockInTriage', () => {
     expect(wrapper.find('[data-testid="item-error-6"]').exists()).toBe(true)
     expect(wrapper.get('[data-testid="item-error-6"]').text()).toContain('Today is full')
   })
+
+  it('ClockInTriage_ShowsInlineError_WhenLaterMoveReturns422', async () => {
+    const item = createMockItem({ id: 7, title: 'Full later day test' })
+    const error = Object.assign(new Error('422'), { response: { status: 422 } })
+    mockPatch.mockRejectedValue(error)
+
+    const wrapper = mount(ClockInTriage, { props: { items: [item] } })
+
+    await wrapper.get('[data-testid="later-btn-7"]').trigger('click')
+    await Promise.resolve()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="item-error-7"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="item-error-7"]').text()).toContain('That day is full')
+  })
 })

--- a/web/src/components/ClockInTriage.spec.ts
+++ b/web/src/components/ClockInTriage.spec.ts
@@ -1,0 +1,145 @@
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { nextTick } from 'vue'
+import type { Mock } from 'vitest'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('@/utils/week', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/week')>()
+  return { ...actual, getToday: vi.fn() }
+})
+
+import client from '@/api/client'
+import { getToday } from '@/utils/week'
+import ClockInTriage from './ClockInTriage.vue'
+import type { WorkItem } from '@/types'
+
+const mockPatch = (client as any).patch as Mock
+const mockGetToday = getToday as Mock
+
+const createMockItem = (overrides: Partial<WorkItem> = {}): WorkItem => ({
+  id: 1,
+  title: 'Default task',
+  category: 'SmallThing',
+  isDone: false,
+  sortOrder: 1,
+  date: '2026-04-09',
+  weekOf: '2026-04-06',
+  originalDate: '2026-04-09',
+  timesMoved: 0,
+  isSkipped: false,
+  ...overrides,
+})
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+  // Default to Wednesday so isMonday is false
+  mockGetToday.mockReturnValue('2026-04-08')
+})
+
+describe('ClockInTriage', () => {
+  it('ClockInTriage_ShowsEmptyState_WhenNoItemsAndNotMonday', () => {
+    const wrapper = mount(ClockInTriage, { props: { items: [] } })
+
+    expect(wrapper.find('[data-testid="triage-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="monday-line"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="triage-list"]').exists()).toBe(false)
+  })
+
+  it('ClockInTriage_ShowsMondayLine_WhenMondayAndNoItems', () => {
+    mockGetToday.mockReturnValue('2026-04-06') // Monday
+
+    const wrapper = mount(ClockInTriage, { props: { items: [] } })
+
+    expect(wrapper.find('[data-testid="monday-line"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="triage-empty"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="monday-line"]').text()).toContain('Case of the Mondays')
+  })
+
+  it('ClockInTriage_RendersTodayButtonsForEachItem_WhenItemsPresent', () => {
+    const items = [
+      createMockItem({ id: 1, title: 'Task one' }),
+      createMockItem({ id: 2, title: 'Task two' }),
+    ]
+
+    const wrapper = mount(ClockInTriage, { props: { items } })
+
+    expect(wrapper.find('[data-testid="triage-list"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-testid^="triage-item-"]')).toHaveLength(2)
+    expect(wrapper.find('[data-testid="today-btn-1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="later-btn-1"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="ignore-btn-1"]').exists()).toBe(true)
+  })
+
+  it('ClockInTriage_RendersCapacityMeter_WithCorrectCount', () => {
+    // Store has items for today; use mock
+    const wrapper = mount(ClockInTriage, { props: { items: [] } })
+
+    expect(wrapper.find('[data-testid="capacity-meter"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="capacity-meter"]').text()).toContain('/5')
+  })
+
+  it('ClockInTriage_CallsMoveToToday_WhenTodayButtonClicked', async () => {
+    const item = createMockItem({ id: 3, title: 'Move today test' })
+    mockPatch.mockResolvedValue({ ...item, date: '2026-04-08', timesMoved: 1 })
+
+    const wrapper = mount(ClockInTriage, { props: { items: [item] } })
+
+    await wrapper.get('[data-testid="today-btn-3"]').trigger('click')
+    await nextTick()
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/work-items/3/move', { date: '2026-04-08' })
+  })
+
+  it('ClockInTriage_CallsMoveToLater_WhenLaterButtonClicked', async () => {
+    const item = createMockItem({ id: 4, title: 'Move later test' })
+    // Wednesday → tomorrow = Thursday 2026-04-09
+    mockPatch.mockResolvedValue({ ...item, date: '2026-04-09', timesMoved: 1 })
+
+    const wrapper = mount(ClockInTriage, { props: { items: [item] } })
+
+    await wrapper.get('[data-testid="later-btn-4"]').trigger('click')
+    await nextTick()
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/work-items/4/move', { date: '2026-04-09' })
+  })
+
+  it('ClockInTriage_CallsSkip_WhenIgnoreButtonClicked', async () => {
+    const item = createMockItem({ id: 5, title: 'Skip test' })
+    mockPatch.mockResolvedValue({ ...item, isSkipped: true })
+
+    const wrapper = mount(ClockInTriage, { props: { items: [item] } })
+
+    await wrapper.get('[data-testid="ignore-btn-5"]').trigger('click')
+    await nextTick()
+
+    expect(mockPatch).toHaveBeenCalledWith('/api/work-items/5/skip')
+  })
+
+  it('ClockInTriage_ShowsInlineError_WhenMoveReturns422', async () => {
+    const item = createMockItem({ id: 6, title: 'Full day test' })
+    const error = Object.assign(new Error('422'), { response: { status: 422 } })
+    mockPatch.mockRejectedValue(error)
+
+    const wrapper = mount(ClockInTriage, { props: { items: [item] } })
+
+    await wrapper.get('[data-testid="today-btn-6"]').trigger('click')
+    await Promise.resolve()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="item-error-6"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="item-error-6"]').text()).toContain('Today is full')
+  })
+})

--- a/web/src/components/ClockInTriage.vue
+++ b/web/src/components/ClockInTriage.vue
@@ -46,6 +46,7 @@ async function handleLater(id: number) {
 }
 
 async function handleIgnore(id: number) {
+  delete errors.value[id]
   await store.skip(id)
 }
 </script>

--- a/web/src/components/ClockInTriage.vue
+++ b/web/src/components/ClockInTriage.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useDailyTasksStore } from '@/stores/dailyTasks'
+import type { WorkItem } from '@/types'
+import { getToday } from '@/utils/week'
+
+const MONDAY_LINE = 'Case of the Mondays — Go Get Stuff Done — you got this!'
+
+const { items } = defineProps<{
+  items: WorkItem[]
+}>()
+
+const store = useDailyTasksStore()
+const errors = ref<Record<number, string>>({})
+
+const today = getToday()
+const todayDow = new Date(`${today}T00:00:00`).getDay()
+const isMonday = todayDow === 1
+
+function buildLaterDate(): string {
+  const d = new Date(`${today}T00:00:00`)
+  d.setDate(d.getDate() + (todayDow === 5 ? 3 : 1))
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const laterDate = buildLaterDate()
+
+const todayCount = computed(() =>
+  store.items.filter(t => t.category === 'SmallThing' && t.date === today).length
+)
+
+async function handleToday(id: number) {
+  delete errors.value[id]
+  try {
+    await store.move(id, today)
+  } catch (e: any) {
+    if (e?.response?.status === 422) {
+      errors.value[id] = 'Today is full'
+    }
+  }
+}
+
+async function handleLater(id: number) {
+  delete errors.value[id]
+  await store.move(id, laterDate)
+}
+
+async function handleIgnore(id: number) {
+  await store.skip(id)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <!-- Section header + capacity meter -->
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <span class="text-accent">&gt;&gt;&gt;</span>
+        <span class="text-xs uppercase tracking-widest text-muted-foreground">Carryover From Yesterday</span>
+      </div>
+      <span class="text-xs text-muted-foreground font-mono" data-testid="capacity-meter">
+        Today:
+        <span :class="todayCount >= 5 ? 'text-destructive font-bold' : 'text-foreground'">{{ todayCount }}</span>/5
+      </span>
+    </div>
+
+    <!-- Monday motivational (no lookback on Mondays) -->
+    <div
+      v-if="isMonday"
+      class="flex items-center gap-2 px-3 py-2 bg-card border border-border text-sm"
+      data-testid="monday-line"
+    >
+      <span class="text-primary">$</span>
+      <span class="text-foreground">{{ MONDAY_LINE }}</span>
+    </div>
+
+    <!-- Clean-day empty state -->
+    <div
+      v-else-if="items.length === 0"
+      class="flex items-center gap-2 px-3 py-2 bg-card border border-border text-sm"
+      data-testid="triage-empty"
+    >
+      <span class="text-success font-bold">[✓]</span>
+      <span class="text-foreground">Yesterday was a clean day — go get more done.</span>
+    </div>
+
+    <!-- Triage items -->
+    <ul
+      v-else
+      class="flex flex-col gap-1.5"
+      data-testid="triage-list"
+    >
+      <li
+        v-for="item in items"
+        :key="item.id"
+        class="flex flex-col bg-card border border-border"
+        :data-testid="`triage-item-${item.id}`"
+      >
+        <div class="flex items-center gap-3 px-3 py-2">
+          <span class="text-muted-foreground">•</span>
+          <span class="text-foreground text-sm flex-1">{{ item.title }}</span>
+          <button
+            type="button"
+            class="text-xs text-accent hover:underline font-mono"
+            :data-testid="`today-btn-${item.id}`"
+            @click="handleToday(item.id)"
+          >
+            [today]
+          </button>
+          <button
+            type="button"
+            class="text-xs text-muted-foreground hover:text-foreground font-mono"
+            :data-testid="`later-btn-${item.id}`"
+            @click="handleLater(item.id)"
+          >
+            [later]
+          </button>
+          <!-- [ignore]: passive let-go of yesterday's residue (clock-in moment). Divergence from [skip] is intentional — see decision 21. -->
+          <button
+            type="button"
+            class="text-xs text-muted-foreground hover:text-foreground font-mono"
+            :data-testid="`ignore-btn-${item.id}`"
+            @click="handleIgnore(item.id)"
+          >
+            [ignore]
+          </button>
+        </div>
+        <div
+          v-if="errors[item.id]"
+          class="px-3 pb-2 text-xs text-destructive"
+          :data-testid="`item-error-${item.id}`"
+        >
+          ! {{ errors[item.id] }}
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/web/src/components/ClockInTriage.vue
+++ b/web/src/components/ClockInTriage.vue
@@ -42,7 +42,13 @@ async function handleToday(id: number) {
 
 async function handleLater(id: number) {
   delete errors.value[id]
-  await store.move(id, laterDate)
+  try {
+    await store.move(id, laterDate)
+  } catch (e: any) {
+    if (e?.response?.status === 422) {
+      errors.value[id] = 'That day is full'
+    }
+  }
 }
 
 async function handleIgnore(id: number) {

--- a/web/src/components/ClockStatus.spec.ts
+++ b/web/src/components/ClockStatus.spec.ts
@@ -1,7 +1,11 @@
-import { mount } from '@vue/test-utils'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import { nextTick } from 'vue'
 import type { Mock } from 'vitest'
+
+// ClockStatus always renders ClockCeremonyModal, which registers a global
+// window keydown listener on mount — unmount wrappers after each test
+enableAutoUnmount(afterEach)
 
 vi.mock('@/api/client', () => ({
   default: {

--- a/web/src/components/ClockStatus.spec.ts
+++ b/web/src/components/ClockStatus.spec.ts
@@ -8,6 +8,7 @@ vi.mock('@/api/client', () => ({
     get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
+    patch: vi.fn(),
     delete: vi.fn(),
   },
 }))
@@ -31,6 +32,10 @@ const createMockSession = (overrides: Partial<WorkSession> = {}): WorkSession =>
 beforeEach(() => {
   setActivePinia(createPinia())
   vi.clearAllMocks()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
 })
 
 describe('ClockStatus', () => {
@@ -75,18 +80,20 @@ describe('ClockStatus', () => {
     expect(wrapper.get('[data-testid="clock-status-out-time"]').text()).toMatch(/^\d{2}:\d{2}:\d{2}$/)
   })
 
-  it('ClockStatus_CallsClockIn_WhenNotInClicked', async () => {
-    mockGet.mockResolvedValue('')
-    mockPost.mockResolvedValue(createMockSession({ clockedInAt: '2026-05-13T13:03:42.000Z' }))
+  it('ClockStatus_OpensCeremonyModal_WhenNotInClicked', async () => {
+    // First GET = workSession (null session), second GET = dailyTasks fetch (empty array)
+    mockGet.mockResolvedValueOnce('').mockResolvedValue([])
 
-    const wrapper = mount(ClockStatus)
+    const wrapper = mount(ClockStatus, { attachTo: document.body })
     await flushAsync()
 
     await wrapper.get('[data-testid="clock-status-not-in"]').trigger('click')
     await flushAsync()
 
-    expect(mockPost).toHaveBeenCalledWith('/api/work-sessions/clock-in', null, { params: { date: expect.any(String) } })
-    expect(wrapper.find('[data-testid="clock-status-in"]').exists()).toBe(true)
+    // Modal Teleports to body — query from document
+    const modal = document.body.querySelector('[data-testid="ceremony-modal"]')
+    expect(modal).not.toBeNull()
+    expect(mockPost).not.toHaveBeenCalled()
   })
 
   it('ClockStatus_CallsClockOut_WhenClockOutClicked', async () => {

--- a/web/src/components/ClockStatus.vue
+++ b/web/src/components/ClockStatus.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useWorkSessionStore } from '@/stores/workSession'
+import ClockCeremonyModal from '@/components/ClockCeremonyModal.vue'
 
 const store = useWorkSessionStore()
+
+const ceremonyOpen = ref(false)
+const ceremonyMode = ref<'in' | 'out'>('in')
 
 const state = computed<'not-in' | 'in' | 'out'>(() => {
   const session = store.today
@@ -23,14 +27,19 @@ function formatTime(iso: string | null): string {
   return `${hh}:${mm}:${ss}`
 }
 
-async function handleClockIn() {
+function handleClockIn() {
   if (state.value !== 'not-in') return
-  await store.clockIn()
+  ceremonyMode.value = 'in'
+  ceremonyOpen.value = true
 }
 
 async function handleClockOut() {
   if (state.value !== 'in') return
   await store.clockOut()
+}
+
+function handleCeremonyClose() {
+  ceremonyOpen.value = false
 }
 
 onMounted(() => {
@@ -81,4 +90,10 @@ onMounted(() => {
     <span v-if="clockedInTime" class="text-muted-foreground">→</span>
     <span class="text-accent" data-testid="clock-status-out-time">{{ clockedOutTime }}</span>
   </div>
+
+  <ClockCeremonyModal
+    :is-open="ceremonyOpen"
+    :mode="ceremonyMode"
+    @close="handleCeremonyClose"
+  />
 </template>

--- a/web/src/stores/dailyTasks.ts
+++ b/web/src/stores/dailyTasks.ts
@@ -71,5 +71,17 @@ export const useDailyTasksStore = defineStore('dailyTasks', () => {
     next.sortOrder = temp
   }
 
-  return { items, weekOf, currentDay, getTasksForDay, fetch, create, update, remove, moveUp, moveDown }
+  async function move(id: number, date: string): Promise<void> {
+    const updated: WorkItem = await client.patch(`/api/work-items/${id}/move`, { date }) as any
+    const idx = items.value.findIndex(t => t.id === id)
+    if (idx !== -1) items.value[idx] = updated
+  }
+
+  async function skip(id: number): Promise<void> {
+    const updated: WorkItem = await client.patch(`/api/work-items/${id}/skip`) as any
+    const idx = items.value.findIndex(t => t.id === id)
+    if (idx !== -1) items.value[idx] = updated
+  }
+
+  return { items, weekOf, currentDay, getTasksForDay, fetch, create, update, remove, moveUp, moveDown, move, skip }
 })

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -17,6 +17,8 @@
   --muted-foreground: oklch(0.55 0.05 255);
   --accent: oklch(0.7 0.18 55);
   --accent-foreground: oklch(0.2 0.05 55);
+  --success: oklch(0.50 0.09 155);
+  --success-foreground: oklch(0.96 0.01 85);
   --destructive: oklch(0.55 0.2 25);
   --destructive-foreground: oklch(0.98 0 0);
   --border: oklch(0.8 0.02 255);
@@ -42,6 +44,8 @@
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
@@ -60,6 +64,25 @@
 @keyframes blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
+}
+
+@utility animate-scan-sweep {
+  animation: scan-sweep 0.18s linear forwards;
+}
+
+@keyframes scan-sweep {
+  0%   { left: 0%;   opacity: 1; }
+  90%  { left: 100%; opacity: 1; }
+  100% { left: 100%; opacity: 0; }
+}
+
+@utility animate-success-flash {
+  animation: success-flash 0.7s ease-out forwards;
+}
+
+@keyframes success-flash {
+  0%, 100% { background-color: var(--color-background); }
+  25%      { background-color: color-mix(in oklab, var(--color-success) 15%, var(--color-background)); }
 }
 
 @layer base {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -6,6 +6,9 @@ export interface WorkItem {
   sortOrder: number
   date: string
   weekOf: string
+  originalDate: string
+  timesMoved: number
+  isSkipped: boolean
 }
 
 export type CommandType = 'standup' | 'weekly' | 'evaluate-my-week' | 'punch'

--- a/web/src/utils/week.spec.ts
+++ b/web/src/utils/week.spec.ts
@@ -1,4 +1,4 @@
-import { DAYS, getToday, getWeekStart, getCurrentDayIndex, getDateForDayIndex, getRecentWeekStarts, formatWeekRange } from './week'
+import { DAYS, getToday, getWeekStart, getCurrentDayIndex, getDateForDayIndex, getRecentWeekStarts, formatWeekRange, getPreviousWorkday } from './week'
 
 describe('week utils', () => {
   describe('DAYS', () => {
@@ -174,6 +174,42 @@ describe('week utils', () => {
         '2026-04-27',
         '2026-04-20',
       ])
+    })
+  })
+
+  describe('getPreviousWorkday', () => {
+    it('getPreviousWorkday_ReturnsNull_OnMonday', () => {
+      expect(getPreviousWorkday('2026-04-06')).toBeNull()
+    })
+
+    it('getPreviousWorkday_ReturnsPreviousDay_OnTuesdayToMonday', () => {
+      expect(getPreviousWorkday('2026-04-07')).toBe('2026-04-06')
+    })
+
+    it('getPreviousWorkday_ReturnsPreviousDay_OnWednesdayToTuesday', () => {
+      expect(getPreviousWorkday('2026-04-08')).toBe('2026-04-07')
+    })
+
+    it('getPreviousWorkday_ReturnsPreviousDay_OnThursdayToWednesday', () => {
+      expect(getPreviousWorkday('2026-04-09')).toBe('2026-04-08')
+    })
+
+    it('getPreviousWorkday_ReturnsPreviousDay_OnFridayToThursday', () => {
+      expect(getPreviousWorkday('2026-04-10')).toBe('2026-04-09')
+    })
+
+    it('getPreviousWorkday_ReturnsNull_OnSaturday', () => {
+      expect(getPreviousWorkday('2026-04-11')).toBeNull()
+    })
+
+    it('getPreviousWorkday_ReturnsNull_OnSunday', () => {
+      expect(getPreviousWorkday('2026-04-12')).toBeNull()
+    })
+
+    it('getPreviousWorkday_UsesToday_WhenNoArgumentGiven', () => {
+      vi.setSystemTime(new Date('2026-04-09T12:00:00Z')) // Thursday
+
+      expect(getPreviousWorkday()).toBe('2026-04-08')
     })
   })
 

--- a/web/src/utils/week.ts
+++ b/web/src/utils/week.ts
@@ -36,6 +36,14 @@ export function getDateForDayIndex(dayIndex: number, weekStart?: string): string
   return toLocalDateString(monday)
 }
 
+export function getPreviousWorkday(today: string = getToday()): string | null {
+  const d = parseLocalDate(today)
+  const dow = d.getDay()
+  if (dow === 0 || dow === 1 || dow === 6) return null // Sun, Mon, Sat — no lookback
+  d.setDate(d.getDate() - 1)
+  return toLocalDateString(d)
+}
+
 export function getRecentWeekStarts(count: number): string[] {
   const result: string[] = []
   const monday = parseLocalDate(getWeekStart())


### PR DESCRIPTION
## Summary

PR A of the clock ceremony plan ([polished-sleeping-fog.md](docs/feature-plans/polished-sleeping-fog.md)). Replaces the bare-line clock-in with a full ceremony modal that surfaces yesterday's carryover SmallThings for triage before clocking in. Stacked on `feat/punching-in-out`.

## Backend

- `WorkItem` entity: added `OriginalDate`, `TimesMoved`, `IsSkipped` (all nullable/default-safe)
- Migration `AddCarryoverMetadataToWorkItems` with backfill SQL (`OriginalDate = Date` for existing rows)
- `PATCH /{id}/move` — moves item to target date, enforces SmallThing 5-cap (422), recomputes `WeekOf`
- `PATCH /{id}/skip` — sets `IsSkipped = true`
- `OriginalDate` set on POST creation

## Frontend

- `getPreviousWorkday()` utility (null on Mon/Sat/Sun)
- `move()` / `skip()` actions on the dailyTasks store
- **`ClockInTriage.vue`** — capacity meter (`Today: N/5`), Monday motivational line, clean-day empty state, inline per-item 422 errors, `[today]`/`[later]`/`[ignore]` actions
- **`ClockCeremonyModal.vue`** — shared shell (teleport, backdrop, punch-card slot, footer), optimistic submit with animation + soft-fail terminal error, `C`/`E`/Escape keyboard
- `ClockStatus.vue` — clicking clock-in opens the ceremony modal instead of calling `clockIn()` directly (clock-out still direct until PR B)

## Tests

- 7 new API tests (move valid/422/404/week-boundary, skip valid/404, OriginalDate-on-create)
- 21 new Vue tests across `ClockInTriage.spec.ts`, `ClockCeremonyModal.spec.ts`, plus `getPreviousWorkday` cases and updated `ClockStatus.spec.ts`
- Full suite: **158 web tests pass**, all API tests pass, lint clean

## Manual verification notes

To smoke-test: spin up Aspire, click `$ clock-in`. Seed a few incomplete SmallThings on yesterday's date first to exercise the triage list; an empty yesterday shows the clean-day state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)