### PR TITLE
chore(web): add playwright devDependency after clock-ceremony spike cleanup

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,6 +32,7 @@
         "globals": "^17.6.0",
         "jiti": "^2.7.0",
         "jsdom": "^27.0.1",
+        "playwright": "^1.60.0",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.2",
@@ -4908,6 +4909,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "globals": "^17.6.0",
     "jiti": "^2.7.0",
     "jsdom": "^27.0.1",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.2",


### PR DESCRIPTION
## What

Closes out the clock-ceremony work (PRs #94 + #97, both merged) by retaining the one keeper from the throwaway visual spike: **playwright** as a declared `devDependency` for future prototyping.

## Context

The clock-ceremony visual spike (`ClockCeremonySpike.vue`, `PunchClockSpike.vue`, `PunchSpikeView.vue`, screenshot scripts, root `spike-*.png`, and a `/punch-spike` route) was **never committed to mainline** — it lived only in the local working tree. Cleanup was therefore a local operation: spike artifacts deleted and the `/punch-spike` route reverted from `router.ts`.

This PR carries the single intended survivor from that cleanup.

## Changes

- Add `playwright ^1.60.0` to `web/package.json` devDependencies
- Corresponding `web/package-lock.json` entries (`playwright`, `playwright-core`, `fsevents`)

No app code, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)