### PR TITLE
feat(web): visualize carried-over tasks on daily and weekly views

### DIFF
--- a/web/src/components/DailyTasks.spec.ts
+++ b/web/src/components/DailyTasks.spec.ts
@@ -1,0 +1,163 @@
+import { mount } from '@vue/test-utils'
+import { ref, nextTick } from 'vue'
+import DailyTasks from './DailyTasks.vue'
+import type { WorkItem } from '@/types'
+
+const WEEK_START = '2026-04-06' // Mon
+const DATE_MAP: Record<number, string> = {
+  0: '2026-04-06', // MON
+  1: '2026-04-07', // TUE
+  2: '2026-04-08', // WED (today)
+  3: '2026-04-09', // THU
+  4: '2026-04-10', // FRI
+}
+
+// --- module mocks ---
+
+vi.mock('@/utils/week', () => ({
+  DAYS: ['MON', 'TUE', 'WED', 'THU', 'FRI'],
+  getWeekStart: () => WEEK_START,
+  getCurrentDayIndex: () => 2,
+  getDateForDayIndex: (dayIndex: number) => DATE_MAP[dayIndex] ?? '',
+  getCarriedDays: (originalDate: string, date: string) =>
+    Math.round((new Date(`${date}T00:00:00`).getTime() - new Date(`${originalDate}T00:00:00`).getTime()) / 86_400_000),
+  getDayLabel: (date: string) =>
+    ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][new Date(`${date}T00:00:00`).getDay()],
+  isCarriedThrough: (originalDate: string, date: string, columnDate: string) =>
+    originalDate <= columnDate && columnDate < date,
+}))
+
+const mockItems = ref<WorkItem[]>([])
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockRemove = vi.fn()
+
+vi.mock('@/stores/dailyTasks', () => ({
+  useDailyTasksStore: () => ({
+    items: mockItems,
+    weekOf: WEEK_START,
+    currentDay: 2,
+    getTasksForDay: (day: number) => {
+      const date = DATE_MAP[day]
+      return mockItems.value
+        .filter(t => t.category === 'SmallThing' && t.date === date)
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+    },
+    getGhostTasksForDay: (day: number) => {
+      const columnDate = DATE_MAP[day]
+      return mockItems.value
+        .filter(t => t.category === 'SmallThing'
+          && t.date !== t.originalDate
+          && t.originalDate <= columnDate && columnDate < t.date)
+        .sort((a, b) => a.date.localeCompare(b.date))
+    },
+    fetch: vi.fn(),
+    create: mockCreate,
+    update: mockUpdate,
+    remove: mockRemove,
+  }),
+}))
+
+// --- helpers ---
+
+let nextId = 1
+
+const createWorkItem = (overrides: Partial<WorkItem> = {}): WorkItem => ({
+  id: nextId++,
+  title: 'Test task',
+  category: 'SmallThing',
+  isDone: false,
+  sortOrder: 0,
+  date: DATE_MAP[2]!,
+  weekOf: WEEK_START,
+  originalDate: DATE_MAP[2]!,
+  timesMoved: 0,
+  isSkipped: false,
+  ...overrides,
+})
+
+describe('DailyTasks', () => {
+  beforeEach(() => {
+    nextId = 1
+    mockItems.value = []
+    mockCreate.mockReset()
+    mockUpdate.mockReset()
+    mockRemove.mockReset()
+  })
+
+  it('DailyTasks_RendersFiveDayColumns', () => {
+    const wrapper = mount(DailyTasks)
+
+    const text = wrapper.text()
+    expect(text).toContain('MON')
+    expect(text).toContain('TUE')
+    expect(text).toContain('WED')
+    expect(text).toContain('THU')
+    expect(text).toContain('FRI')
+  })
+
+  it('DailyTasks_ShowsCarryBadge_WhenTaskIsCarried', async () => {
+    const wrapper = mount(DailyTasks)
+    // orig Mon, due Wed → 2 days
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Carried', originalDate: DATE_MAP[0], date: DATE_MAP[2] }),
+    ]
+    await nextTick()
+
+    const badges = wrapper.findAll('[data-testid="carry-badge"]')
+    expect(badges).toHaveLength(1)
+    expect(badges[0]!.text()).toContain('2d')
+    expect(badges[0]!.attributes('title')).toBe('carried 2 days')
+  })
+
+  it('DailyTasks_HidesCarryBadge_WhenTaskNotCarried', async () => {
+    const wrapper = mount(DailyTasks)
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Fresh', originalDate: DATE_MAP[2], date: DATE_MAP[2] }),
+    ]
+    await nextTick()
+
+    expect(wrapper.findAll('[data-testid="carry-badge"]')).toHaveLength(0)
+  })
+
+  it('DailyTasks_RendersGhostBreadcrumb_OnEachPassThroughDay', async () => {
+    const wrapper = mount(DailyTasks)
+    // orig Mon, due Wed → ghosts on Mon and Tue, live (badge) on Wed
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Passing', originalDate: DATE_MAP[0], date: DATE_MAP[2] }),
+    ]
+    await nextTick()
+
+    const ghostRows = wrapper.findAll('[data-testid="ghost-row"]')
+    expect(ghostRows).toHaveLength(2)
+    ghostRows.forEach(row => {
+      expect(row.text()).toContain('Passing')
+      expect(row.text()).toContain('WED') // destination
+    })
+    // Live row + badge appears exactly once (on Wed)
+    expect(wrapper.findAll('[data-testid="carry-badge"]')).toHaveLength(1)
+  })
+
+  it('DailyTasks_GhostSection_HasNoInteractiveControls', async () => {
+    const wrapper = mount(DailyTasks)
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Passing', originalDate: DATE_MAP[1], date: DATE_MAP[2] }),
+    ]
+    await nextTick()
+
+    const ghostSection = wrapper.get('[data-testid="ghost-section"]')
+    expect(ghostSection.find('button').exists()).toBe(false)
+    expect(ghostSection.find('input').exists()).toBe(false)
+    expect(ghostSection.find('[data-testid="carry-badge"]').exists()).toBe(false)
+  })
+
+  it('DailyTasks_NoGhostSection_WhenNothingPassesThrough', async () => {
+    const wrapper = mount(DailyTasks)
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Fresh', originalDate: DATE_MAP[2], date: DATE_MAP[2] }),
+    ]
+    await nextTick()
+
+    expect(wrapper.findAll('[data-testid="ghost-section"]')).toHaveLength(0)
+  })
+})

--- a/web/src/components/DailyTasks.vue
+++ b/web/src/components/DailyTasks.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, nextTick } from 'vue'
 import { useDailyTasksStore } from '@/stores/dailyTasks'
-import { DAYS } from '@/utils/week'
+import { DAYS, getCarriedDays, getDayLabel } from '@/utils/week'
+import type { WorkItem } from '@/types'
 
 const store = useDailyTasksStore()
 
@@ -43,6 +44,10 @@ async function toggleTask(id: number, currentDone: boolean) {
 
 async function deleteTask(id: number) {
   await store.remove(id)
+}
+
+function carriedDays(task: WorkItem): number {
+  return getCarriedDays(task.originalDate, task.date)
 }
 </script>
 
@@ -96,6 +101,14 @@ async function deleteTask(id: number) {
             >
               {{ task.title }}
             </span>
+            <span
+              v-if="carriedDays(task) > 0"
+              class="flex-shrink-0 self-center text-[10.5px] leading-none whitespace-nowrap text-accent border border-accent/50 bg-accent/5 px-1.5 py-0.5"
+              :title="`carried ${carriedDays(task)} day${carriedDays(task) > 1 ? 's' : ''}`"
+              data-testid="carry-badge"
+            >
+              &#8635; {{ carriedDays(task) }}d
+            </span>
             <button
               class="opacity-0 group-hover:opacity-100 text-destructive text-xs"
               @click="deleteTask(task.id)"
@@ -125,6 +138,30 @@ async function deleteTask(id: number) {
             >
               + add
             </button>
+          </div>
+        </div>
+
+        <!-- Carried-through breadcrumb: read-only trail of tasks passing through this day -->
+        <div
+          v-if="store.getGhostTasksForDay(dayIndex).length > 0"
+          class="mt-3 pt-2 border-t border-dashed border-border"
+          data-testid="ghost-section"
+        >
+          <div class="text-[9.5px] uppercase tracking-[0.1em] text-muted-foreground/80 mb-1.5">
+            carried through
+          </div>
+          <div
+            v-for="ghost in store.getGhostTasksForDay(dayIndex)"
+            :key="`${ghost.id}-ghost`"
+            class="grid grid-cols-[1fr_auto] gap-1.5 items-baseline pl-3.5 text-xs text-muted-foreground"
+            data-testid="ghost-row"
+          >
+            <span class="break-words">
+              <span class="text-muted-foreground/70">&middot;</span> {{ ghost.title }}
+            </span>
+            <span class="text-[10.5px] opacity-80 whitespace-nowrap">
+              &rarr; {{ getDayLabel(ghost.date) }}
+            </span>
           </div>
         </div>
       </div>

--- a/web/src/components/DailyTasks.vue
+++ b/web/src/components/DailyTasks.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { ref, nextTick } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useDailyTasksStore } from '@/stores/dailyTasks'
 import { DAYS, getCarriedDays, getDayLabel } from '@/utils/week'
 import type { WorkItem } from '@/types'
 
 const store = useDailyTasksStore()
+
+// Carried-through ghost rows per day column, computed once per render.
+const ghostsByDay = computed(() => DAYS.map((_, i) => store.getGhostTasksForDay(i)))
 
 const newTask = ref('')
 const addingForDay = ref<number | null>(null)
@@ -143,7 +146,7 @@ function carriedDays(task: WorkItem): number {
 
         <!-- Carried-through breadcrumb: read-only trail of tasks passing through this day -->
         <div
-          v-if="store.getGhostTasksForDay(dayIndex).length > 0"
+          v-if="ghostsByDay[dayIndex].length > 0"
           class="mt-3 pt-2 border-t border-dashed border-border"
           data-testid="ghost-section"
         >
@@ -151,7 +154,7 @@ function carriedDays(task: WorkItem): number {
             carried through
           </div>
           <div
-            v-for="ghost in store.getGhostTasksForDay(dayIndex)"
+            v-for="ghost in ghostsByDay[dayIndex]"
             :key="`${ghost.id}-ghost`"
             class="grid grid-cols-[1fr_auto] gap-1.5 items-baseline pl-3.5 text-xs text-muted-foreground"
             data-testid="ghost-row"

--- a/web/src/components/DailyTasksCompact.spec.ts
+++ b/web/src/components/DailyTasksCompact.spec.ts
@@ -21,6 +21,12 @@ vi.mock('@/utils/week', () => ({
   getWeekStart: () => WEEK_START,
   getCurrentDayIndex: () => 2,
   getDateForDayIndex: (dayIndex: number) => DATE_MAP[dayIndex] ?? '',
+  getCarriedDays: (originalDate: string, date: string) =>
+    Math.round((new Date(`${date}T00:00:00`).getTime() - new Date(`${originalDate}T00:00:00`).getTime()) / 86_400_000),
+  getDayLabel: (date: string) =>
+    ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][new Date(`${date}T00:00:00`).getDay()],
+  isCarriedThrough: (originalDate: string, date: string, columnDate: string) =>
+    originalDate <= columnDate && columnDate < date,
 }))
 
 // Make debounce immediate so auto-save fires synchronously in tests
@@ -46,6 +52,14 @@ vi.mock('@/stores/dailyTasks', () => ({
       return mockItems.value
         .filter(t => t.category === 'SmallThing' && t.date === date)
         .sort((a, b) => a.sortOrder - b.sortOrder)
+    },
+    getGhostTasksForDay: (day: number) => {
+      const columnDate = DATE_MAP[day]
+      return mockItems.value
+        .filter(t => t.category === 'SmallThing'
+          && t.date !== t.originalDate
+          && t.originalDate <= columnDate && columnDate < t.date)
+        .sort((a, b) => a.date.localeCompare(b.date))
     },
     fetch: vi.fn(),
     create: mockCreate,
@@ -424,5 +438,82 @@ describe('DailyTasksCompact', () => {
 
     expect(wrapper.findAll('[data-testid="task-move-up"]')).toHaveLength(0)
     expect(wrapper.findAll('[data-testid="task-move-down"]')).toHaveLength(0)
+  })
+
+  it('DailyTasksCompact_ShowsCarryBadge_WhenTaskIsCarried', async () => {
+    const wrapper = mountComponent()
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Carried task', originalDate: YESTERDAY_DATE, date: TODAY_DATE }),
+    ]
+    await nextTick()
+
+    const badges = wrapper.findAll('[data-testid="carry-badge"]')
+    expect(badges).toHaveLength(1)
+    expect(badges[0]!.text()).toContain('1d')
+    expect(badges[0]!.attributes('title')).toBe('carried 1 day')
+  })
+
+  it('DailyTasksCompact_HidesCarryBadge_WhenTaskNotCarried', async () => {
+    const wrapper = mountComponent()
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Fresh task', originalDate: TODAY_DATE, date: TODAY_DATE }),
+    ]
+    await nextTick()
+
+    expect(wrapper.findAll('[data-testid="carry-badge"]')).toHaveLength(0)
+  })
+
+  it('DailyTasksCompact_CarryBadge_PluralizesDays', async () => {
+    const wrapper = mountComponent()
+    // orig Mon (2026-04-06), due Thu/tomorrow (2026-04-09) → 3 days
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Long carry', originalDate: WEEK_START, date: TOMORROW_DATE }),
+    ]
+    await nextTick()
+
+    const badge = wrapper.get('[data-testid="carry-badge"]')
+    expect(badge.text()).toContain('3d')
+    expect(badge.attributes('title')).toBe('carried 3 days')
+  })
+
+  it('DailyTasksCompact_RendersGhostBreadcrumb_OnPassThroughDay', async () => {
+    const wrapper = mountComponent()
+    // Carried task due today; its trail passes through yesterday
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Passing task', originalDate: YESTERDAY_DATE, date: TODAY_DATE }),
+    ]
+    await nextTick()
+
+    const ghostRows = wrapper.findAll('[data-testid="ghost-row"]')
+    expect(ghostRows).toHaveLength(1)
+    expect(ghostRows[0]!.text()).toContain('Passing task')
+    // due date 2026-04-08 is a Wednesday
+    expect(ghostRows[0]!.text()).toContain('WED')
+  })
+
+  it('DailyTasksCompact_GhostRow_HasNoInteractiveControls', async () => {
+    const wrapper = mountComponent()
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Passing task', originalDate: YESTERDAY_DATE, date: TODAY_DATE }),
+    ]
+    await nextTick()
+
+    const ghostSection = wrapper.get('[data-testid="ghost-section"]')
+    expect(ghostSection.find('[data-testid="task-toggle"]').exists()).toBe(false)
+    expect(ghostSection.find('[data-testid="task-delete"]').exists()).toBe(false)
+    expect(ghostSection.find('[data-testid="carry-badge"]').exists()).toBe(false)
+  })
+
+  it('DailyTasksCompact_CarriedTask_RendersLiveOnce_AndGhostElsewhere_NoDoubleRender', async () => {
+    const wrapper = mountComponent()
+    mockItems.value = [
+      createWorkItem({ id: 1, title: 'Only once', originalDate: YESTERDAY_DATE, date: TODAY_DATE }),
+    ]
+    await nextTick()
+
+    // One live row (with its badge), one ghost row on the pass-through column — never both on the same day
+    expect(wrapper.findAll('[data-testid="carry-badge"]')).toHaveLength(1)
+    expect(wrapper.findAll('[data-testid="ghost-row"]')).toHaveLength(1)
+    expect(wrapper.findAll('[data-testid="task-title"]')).toHaveLength(1)
   })
 })

--- a/web/src/components/DailyTasksCompact.vue
+++ b/web/src/components/DailyTasksCompact.vue
@@ -16,14 +16,17 @@ const editOriginalValue = ref('')
 
 const displayDays = computed(() => {
   const day = store.currentDay
-  const yesterday = day - 1
-  const tomorrow = day + 1
 
   return [
-    { index: yesterday, label: 'YESTERDAY', shortLabel: yesterday >= 0 && yesterday < 5 ? DAYS[yesterday] : null },
-    { index: day, label: 'TODAY', shortLabel: day >= 0 && day < 5 ? DAYS[day] : null },
-    { index: tomorrow, label: 'TOMORROW', shortLabel: tomorrow >= 0 && tomorrow < 5 ? DAYS[tomorrow] : null },
-  ]
+    { index: day - 1, label: 'YESTERDAY' },
+    { index: day, label: 'TODAY' },
+    { index: day + 1, label: 'TOMORROW' },
+  ].map(({ index, label }) => ({
+    index,
+    label,
+    shortLabel: index >= 0 && index < 5 ? DAYS[index] : null,
+    ghosts: store.getGhostTasksForDay(index),
+  }))
 })
 
 function isOutOfRange(index: number) {
@@ -133,7 +136,7 @@ function cancelEdit() {
 
     <div class="grid gap-3" style="grid-template-columns: 1fr 2fr 1fr">
       <div
-        v-for="{ index, label, shortLabel } in displayDays"
+        v-for="{ index, label, shortLabel, ghosts } in displayDays"
         :key="label"
         :class="[
           'border p-4 min-h-[160px]',
@@ -277,7 +280,7 @@ function cancelEdit() {
 
           <!-- Carried-through breadcrumb: read-only trail of tasks passing through this column -->
           <div
-            v-if="store.getGhostTasksForDay(index).length > 0"
+            v-if="ghosts.length > 0"
             class="mt-3 pt-2 border-t border-dashed border-border"
             data-testid="ghost-section"
           >
@@ -285,7 +288,7 @@ function cancelEdit() {
               carried through
             </div>
             <div
-              v-for="ghost in store.getGhostTasksForDay(index)"
+              v-for="ghost in ghosts"
               :key="`${ghost.id}-ghost`"
               class="grid grid-cols-[1fr_auto] gap-2 items-baseline pl-3.5 text-sm text-muted-foreground"
               data-testid="ghost-row"

--- a/web/src/components/DailyTasksCompact.vue
+++ b/web/src/components/DailyTasksCompact.vue
@@ -2,7 +2,8 @@
 import { ref, computed, nextTick } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { useDailyTasksStore } from '@/stores/dailyTasks'
-import { DAYS } from '@/utils/week'
+import { DAYS, getCarriedDays, getDayLabel } from '@/utils/week'
+import type { WorkItem } from '@/types'
 
 const store = useDailyTasksStore()
 
@@ -31,6 +32,10 @@ function isOutOfRange(index: number) {
 
 function isEditable(label: string) {
   return label === 'TODAY' || label === 'TOMORROW'
+}
+
+function carriedDays(task: WorkItem): number {
+  return getCarriedDays(task.originalDate, task.date)
 }
 
 function startAdding(day: number) {
@@ -200,6 +205,15 @@ function cancelEdit() {
               {{ task.title }}
             </span>
 
+            <span
+              v-if="carriedDays(task) > 0"
+              class="flex-shrink-0 self-center text-[10.5px] leading-none whitespace-nowrap text-accent border border-accent/50 bg-accent/5 px-1.5 py-0.5"
+              :title="`carried ${carriedDays(task)} day${carriedDays(task) > 1 ? 's' : ''}`"
+              data-testid="carry-badge"
+            >
+              &#8635; {{ carriedDays(task) }}d
+            </span>
+
             <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100">
               <template v-if="isEditable(label)">
                 <button
@@ -259,6 +273,30 @@ function cancelEdit() {
             >
               + add
             </button>
+          </div>
+
+          <!-- Carried-through breadcrumb: read-only trail of tasks passing through this column -->
+          <div
+            v-if="store.getGhostTasksForDay(index).length > 0"
+            class="mt-3 pt-2 border-t border-dashed border-border"
+            data-testid="ghost-section"
+          >
+            <div class="text-[9.5px] uppercase tracking-[0.1em] text-muted-foreground/80 mb-1.5">
+              carried through
+            </div>
+            <div
+              v-for="ghost in store.getGhostTasksForDay(index)"
+              :key="`${ghost.id}-ghost`"
+              class="grid grid-cols-[1fr_auto] gap-2 items-baseline pl-3.5 text-sm text-muted-foreground"
+              data-testid="ghost-row"
+            >
+              <span class="break-words">
+                <span class="text-muted-foreground/70">&middot;</span> {{ ghost.title }}
+              </span>
+              <span class="text-[10.5px] opacity-80 whitespace-nowrap">
+                &rarr; {{ getDayLabel(ghost.date) }}
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/stores/dailyTasks.ts
+++ b/web/src/stores/dailyTasks.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import client from '@/api/client'
 import type { WorkItem } from '@/types'
-import { getWeekStart, getCurrentDayIndex, getDateForDayIndex } from '@/utils/week'
+import { getWeekStart, getCurrentDayIndex, getDateForDayIndex, isCarriedThrough } from '@/utils/week'
 
 export const useDailyTasksStore = defineStore('dailyTasks', () => {
   const items = ref<WorkItem[]>([])
@@ -14,6 +14,17 @@ export const useDailyTasksStore = defineStore('dailyTasks', () => {
     return items.value
       .filter(t => t.category === 'SmallThing' && t.date === date)
       .sort((a, b) => a.sortOrder - b.sortOrder)
+  }
+
+  // Carried tasks whose trail passes through this day but that live (are due) elsewhere.
+  // Read-only breadcrumbs — never includes the day the task is due (it's a live row there).
+  function getGhostTasksForDay(day: number) {
+    const columnDate = getDateForDayIndex(day, weekOf.value)
+    return items.value
+      .filter(t => t.category === 'SmallThing'
+        && t.date !== t.originalDate
+        && isCarriedThrough(t.originalDate, t.date, columnDate))
+      .sort((a, b) => a.date.localeCompare(b.date))
   }
 
   async function fetch(week?: string) {
@@ -83,5 +94,5 @@ export const useDailyTasksStore = defineStore('dailyTasks', () => {
     if (idx !== -1) items.value[idx] = updated
   }
 
-  return { items, weekOf, currentDay, getTasksForDay, fetch, create, update, remove, moveUp, moveDown, move, skip }
+  return { items, weekOf, currentDay, getTasksForDay, getGhostTasksForDay, fetch, create, update, remove, moveUp, moveDown, move, skip }
 })

--- a/web/src/utils/week.ts
+++ b/web/src/utils/week.ts
@@ -55,6 +55,28 @@ export function getRecentWeekStarts(count: number): string[] {
   return result
 }
 
+const WEEKDAY_CODES = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const
+
+// Weekday code (MON..FRI, plus SUN/SAT for weekend dates) for a yyyy-MM-dd string.
+// Used for the ghost breadcrumb "→ DEST" destination label.
+export function getDayLabel(date: string): string {
+  return WEEKDAY_CODES[parseLocalDate(date).getDay()]!
+}
+
+export function getCarriedDays(originalDate: string, date: string): number {
+  const orig = parseLocalDate(originalDate)
+  const due = parseLocalDate(date)
+  const ms = due.getTime() - orig.getTime()
+  return Math.round(ms / 86_400_000)
+}
+
+// A carried task passes "through" a column when the column's date falls on or
+// after its original day but strictly before its current due day. It renders as
+// a live row only on its due day, so the due day is never also a ghost.
+export function isCarriedThrough(originalDate: string, date: string, columnDate: string): boolean {
+  return originalDate <= columnDate && columnDate < date
+}
+
 const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 export function formatWeekRange(weekStart: string): string {


### PR DESCRIPTION
## Summary

Adds a visual language for **carried-over tasks** — a task whose current due date is later than the day it was first planned ("rolled forward") — to both the daily (Yesterday/Today/Tomorrow) and weekly (Mon–Fri) task views. Recreates the Variant D design handoff in `docs/protoypes/design_handoff_carry_over` using the app's existing Vue components and semantic design tokens.

Two visual pieces:
- **`⟳ Nd` carry badge** on the live task row (N = days carried).
- **"carried through" ghost breadcrumb** — a read-only trail (`· title  → DEST`) shown on every day the task's trail passes through but doesn't land.

## Key point: no backend changes

The data model already supports this — `WorkItem.Date` (current due) and `WorkItem.OriginalDate` (first planned) already exist, and the `PATCH /move` endpoint already preserves `OriginalDate`. This PR is **frontend-only**: no entity, DTO, endpoint, or migration changes.

`carried = date !== originalDate`; `carriedDays` = calendar-day difference.

## Changes

- **`utils/week.ts`** — `getCarriedDays`, `isCarriedThrough` (pass-through predicate), `getDayLabel` (destination weekday code).
- **`stores/dailyTasks.ts`** — `getGhostTasksForDay(day)` selector shared by both views.
- **`DailyTasksCompact.vue`** (daily) & **`DailyTasks.vue`** (weekly) — badge on live rows + read-only ghost section. Existing edit/move/delete/add behavior untouched.

## Design decisions

- **Semantic tokens, not raw hex.** The handoff shipped raw `--term-*` hex; per the repo's design-system rule these map onto existing tokens (`text-accent` badge, `text-muted-foreground` ghosts, `border-border` dashed rules). Visually equivalent, lint-clean.
- **Unified ghost placement.** The prototype's two views had inconsistent rules (`orig ≤ d < due` vs `orig < d ≤ due`, the latter double-rendering on the due day). Unified to `originalDate ≤ columnDate < date`, so a task is a live row on its due day and a ghost everywhere else its trail crosses — never both.

## Testing

- `npm run test` — 199 passed (16 files), including new coverage for badge visibility/pluralization, ghost placement on pass-through days, ghosts being read-only, and the no-double-render guarantee.
- `npm run lint` — clean.
- `vue-tsc -b` — clean.
- Manual verification in the running Aspire app still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)