### PR TITLE
feat: standup planning session modal

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -32,6 +32,7 @@ All colors are OKLCH CSS variables defined in `:root` and exposed to Tailwind as
 | `muted-foreground` | `oklch(0.55 0.05 255)` | Secondary text, labels, placeholders, inactive |
 | `accent` | `oklch(0.7 0.18 55)` | **Golden highlight** — `>>>`, emphasis, the "one thing", key numbers |
 | `accent-foreground` | `oklch(0.2 0.05 55)` | Text on accent fills |
+| `lunch` | `oklch(0.72 0.13 95)` | Muted mustard-gold — recommended lunch block on the standup forecast timeline; a distinct gold so it doesn't read as `accent` |
 | `success` | `oklch(0.50 0.09 155)` | Completion flashes (used via `animate-success-flash`) |
 | `destructive` | `oklch(0.55 0.2 25)` | Delete actions, errors |
 | `border` | `oklch(0.8 0.02 255)` | Every border, every divider |

--- a/api/src/Dtos/ForecastDtos.cs
+++ b/api/src/Dtos/ForecastDtos.cs
@@ -1,0 +1,3 @@
+namespace DailyWork.Api.Dtos;
+
+internal record UploadForecastDto(string Json);

--- a/api/src/Endpoints/ForecastEndpoints.cs
+++ b/api/src/Endpoints/ForecastEndpoints.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using DailyWork.Api.Data;
+using DailyWork.Api.Dtos;
+using DailyWork.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyWork.Api.Endpoints;
+
+internal static class ForecastEndpoints
+{
+	public static RouteGroupBuilder MapForecastEndpoints(this WebApplication app)
+	{
+		var group = app.MapGroup("/api/forecast");
+
+		group.MapGet("/", async (AppDbContext db, IDateTimeProvider dateTime, IConfiguration config, IWebHostEnvironment env, DateOnly date) =>
+		{
+			var fileName = ForecastFileName(date);
+			var session = await db.WorkSessions.SingleOrDefaultAsync(s => s.Date == date);
+
+			if (session?.CalendarForecastJson is not null)
+				return Results.Ok(new { json = session.CalendarForecastJson, fileName, source = "database" });
+
+			var filePath = Path.Combine(ResolveForecastDirectory(config, env), fileName);
+			if (!File.Exists(filePath))
+				return Results.NotFound();
+
+			var text = await File.ReadAllTextAsync(filePath);
+			if (!IsValidJson(text))
+				return Results.Problem($"Forecast file '{fileName}' contains invalid JSON.", statusCode: 422);
+
+			if (session is null)
+			{
+				session = new WorkSession { Date = date, CreatedAt = dateTime.UtcNow };
+				db.WorkSessions.Add(session);
+			}
+			session.CalendarForecastJson = text;
+			await db.SaveChangesAsync();
+
+			return Results.Ok(new { json = text, fileName, source = "file" });
+		});
+
+		group.MapPost("/", async (AppDbContext db, IDateTimeProvider dateTime, UploadForecastDto dto, DateOnly date) =>
+		{
+			if (string.IsNullOrWhiteSpace(dto.Json) || !IsValidJson(dto.Json))
+				return Results.Problem("Invalid JSON", statusCode: 422);
+
+			var session = await db.WorkSessions.SingleOrDefaultAsync(s => s.Date == date);
+			if (session is null)
+			{
+				session = new WorkSession { Date = date, CreatedAt = dateTime.UtcNow };
+				db.WorkSessions.Add(session);
+			}
+			session.CalendarForecastJson = dto.Json;
+			await db.SaveChangesAsync();
+
+			return Results.Ok(new { json = dto.Json, fileName = ForecastFileName(date), source = "upload" });
+		});
+
+		group.MapDelete("/", async (AppDbContext db, DateOnly date) =>
+		{
+			var session = await db.WorkSessions.SingleOrDefaultAsync(s => s.Date == date);
+			if (session is not null)
+			{
+				session.CalendarForecastJson = null;
+				await db.SaveChangesAsync();
+			}
+
+			return Results.NoContent();
+		});
+
+		return group;
+	}
+
+	private static string ForecastFileName(DateOnly date) =>
+		$"daily-forecast-{date:yyyy-MM-dd}.json";
+
+	private static string ResolveForecastDirectory(IConfiguration config, IWebHostEnvironment env)
+	{
+		var dir = config["CalendarForecasts:Directory"] ?? "../../resources/calendar-forecasts";
+		return Path.GetFullPath(dir, env.ContentRootPath);
+	}
+
+	private static bool IsValidJson(string text)
+	{
+		try
+		{
+			using var _ = JsonDocument.Parse(text);
+			return true;
+		}
+		catch (JsonException)
+		{
+			return false;
+		}
+	}
+}

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -193,13 +193,25 @@ internal static class StandupEndpoints
 					learningQueueJson = JsonSerializer.Serialize(consumedItems, JsonOptions);
 			}
 
+			// Include today's calendar forecast (persisted by the planning modal) for daily standups
+			string? forecastJson = null;
+			if (!useWeeklyPrompt)
+			{
+				forecastJson = await db.WorkSessions
+					.AsNoTracking()
+					.Where(s => s.Date == todayDate)
+					.Select(s => s.CalendarForecastJson)
+					.FirstOrDefaultAsync();
+			}
+
 			var chatHistory = new ChatHistory();
 			chatHistory.AddSystemMessage(systemPrompt);
 			chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(
 				workItemsJson,
 				todayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
 				yesterdayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-				learningQueueJson));
+				learningQueueJson,
+				forecastJson));
 
 			var response = await chatService.GetChatMessageContentAsync(chatHistory);
 

--- a/api/src/Entities/WorkSession.cs
+++ b/api/src/Entities/WorkSession.cs
@@ -8,6 +8,7 @@ internal class WorkSession
 	public DateTime? ClockedOutAt { get; set; }
 	public DateTime CreatedAt { get; set; }
 	public WorkSessionReflections? Reflections { get; set; }
+	public string? CalendarForecastJson { get; set; }
 }
 
 internal record WorkSessionReflections

--- a/api/src/Migrations/20260714184426_AddCalendarForecastJsonToWorkSessions.Designer.cs
+++ b/api/src/Migrations/20260714184426_AddCalendarForecastJsonToWorkSessions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyWork.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DailyWork.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714184426_AddCalendarForecastJsonToWorkSessions")]
+    partial class AddCalendarForecastJsonToWorkSessions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/src/Migrations/20260714184426_AddCalendarForecastJsonToWorkSessions.cs
+++ b/api/src/Migrations/20260714184426_AddCalendarForecastJsonToWorkSessions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyWork.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCalendarForecastJsonToWorkSessions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CalendarForecastJson",
+                table: "WorkSessions",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CalendarForecastJson",
+                table: "WorkSessions");
+        }
+    }
+}

--- a/api/src/Program.cs
+++ b/api/src/Program.cs
@@ -49,5 +49,6 @@ app.MapStandupEndpoints();
 app.MapScratchPadEndpoints();
 app.MapCalendarEndpoints();
 app.MapWorkSessionEndpoints();
+app.MapForecastEndpoints();
 
 app.Run();

--- a/api/src/Prompts/StandupPrompts.cs
+++ b/api/src/Prompts/StandupPrompts.cs
@@ -9,11 +9,13 @@ internal static class StandupPrompts
 		_ => GetMidWeekPrompt(),
 	};
 
-	internal static string BuildUserMessage(string workItemsJson, string today, string yesterday, string? learningQueueJson = null)
+	internal static string BuildUserMessage(string workItemsJson, string today, string yesterday, string? learningQueueJson = null, string? forecastJson = null)
 	{
 		var message = $"Today's date: {today}\nYesterday's date: {yesterday}\n\nWork items:\n{workItemsJson}";
 		if (learningQueueJson is not null)
 			message += $"\n\nLearning queue items consumed this week:\n{learningQueueJson}";
+		if (forecastJson is not null)
+			message += $"\n\nDaily calendar forecast:\n{forecastJson}";
 		return message;
 	}
 
@@ -26,6 +28,11 @@ internal static class StandupPrompts
         - isDone: completion status
         - date: scheduled day
         - sortOrder: items are pre-sorted; the FIRST SmallThing for a given date is the "One Thing" / "big thing of the day"
+
+        Daily calendar forecast (a JSON block may be provided at the end of the user message; it may be absent):
+        - syncMeetings: names of sync meetings on today's calendar
+        - upcomingPTO: out-of-office events with title, start, end
+        Use ONLY syncMeetings and upcomingPTO from the forecast — ignore every other forecast field.
 
         Output exactly this structure (use ### for each question heading):
 
@@ -49,9 +56,12 @@ internal static class StandupPrompts
 
         The first line is ONLY today's big thing of the day (first SmallThing by sortOrder for today) tied back to the weekly BigThing.
         Then a BLANK LINE, then "Also on deck:" listing today's remaining SmallThings.
+        If the forecast lists syncMeetings, fold them into the "Also on deck:" line as syncs (e.g. ", plus syncs: Ali / Jared"). Do not repeat a sync that already appears as a task, and do not invent syncs when the forecast is absent.
 
         ### Do you have any upcoming PTO or unavailability the team should know about?
-        No
+        OOO Jul 24 – Jul 30 (Family Time).
+
+        If the forecast's upcomingPTO has entries, answer from it: one fragment per entry formatted "OOO {Mon D} – {Mon D}" from the start/end dates, with the title (leading emoji stripped) in parentheses when it adds context; join multiple entries with "; ". If the forecast is absent or upcomingPTO is empty, answer exactly "No".
 
         Style rules:
         - Write in first person. This gets pasted into Geekbot.
@@ -72,6 +82,11 @@ internal static class StandupPrompts
         - isDone: completion status
         - date: scheduled day
         - sortOrder: items are pre-sorted; the FIRST SmallThing for a given date is the "One Thing" / "big thing of the day"
+
+        Daily calendar forecast (a JSON block may be provided at the end of the user message; it may be absent):
+        - syncMeetings: names of sync meetings on today's calendar
+        - upcomingPTO: out-of-office events with title, start, end
+        Use ONLY syncMeetings and upcomingPTO from the forecast — ignore every other forecast field.
 
         Learning queue item fields (provided separately, may be empty):
         - title: name of the resource
@@ -102,9 +117,12 @@ internal static class StandupPrompts
 
         The first line is ONLY today's big thing of the day (first SmallThing by sortOrder for today) tied back to the weekly BigThing.
         Then a BLANK LINE, then "Also on deck:" listing today's remaining SmallThings.
+        If the forecast lists syncMeetings, fold them into the "Also on deck:" line as syncs (e.g. ", plus syncs: Ali / Jared"). Do not repeat a sync that already appears as a task, and do not invent syncs when the forecast is absent.
 
         ### Do you have any upcoming PTO or unavailability the team should know about?
-        No
+        OOO Jul 24 – Jul 30 (Family Time).
+
+        If the forecast's upcomingPTO has entries, answer from it: one fragment per entry formatted "OOO {Mon D} – {Mon D}" from the start/end dates, with the title (leading emoji stripped) in parentheses when it adds context; join multiple entries with "; ". If the forecast is absent or upcomingPTO is empty, answer exactly "No".
 
         ### What's one experiment, improvement, or lesson from this week that helped you (or could help the team)?
         This week I tried **[title]** — [revised notes as a concise value prop]. Worth checking out: [url]

--- a/api/src/appsettings.json
+++ b/api/src/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "dailywork": ""
+  },
+  "CalendarForecasts": {
+    "Directory": "../../resources/calendar-forecasts"
   }
 }

--- a/api/tests/ForecastEndpointTests.cs
+++ b/api/tests/ForecastEndpointTests.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DailyWork.Api.Tests.Fixtures;
+using Shouldly;
+using Xunit;
+
+namespace DailyWork.Api.Tests;
+
+public class ForecastEndpointTests : IClassFixture<CustomWebApplicationFactory>, IAsyncLifetime
+{
+	private readonly CustomWebApplicationFactory _factory;
+	private readonly HttpClient _client;
+	private readonly string _forecastDir;
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNameCaseInsensitive = true,
+		Converters = { new JsonStringEnumConverter() }
+	};
+
+	private const string TestDate = "2020-01-15";
+	private const string TestFileName = "daily-forecast-2020-01-15.json";
+	private const string SampleJson = """{"date":"2020-01-15","dayOfWeek":"Wednesday","meetings":{"count":2,"totalHours":1.5}}""";
+
+	public ForecastEndpointTests(CustomWebApplicationFactory factory)
+	{
+		_factory = factory;
+		_forecastDir = Directory.CreateTempSubdirectory("forecast-tests").FullName;
+		_client = factory.WithWebHostBuilder(b =>
+			b.UseSetting("CalendarForecasts:Directory", _forecastDir)).CreateClient();
+	}
+
+	public Task InitializeAsync() => _factory.ResetDatabaseAsync();
+
+	public Task DisposeAsync()
+	{
+		Directory.Delete(_forecastDir, recursive: true);
+		return Task.CompletedTask;
+	}
+
+	private Task WriteForecastFileAsync(string content) =>
+		File.WriteAllTextAsync(Path.Combine(_forecastDir, TestFileName), content);
+
+	[Fact]
+	public async Task GetForecast_ReturnsJsonAndFileName_WhenFileExistsOnDisk()
+	{
+		// Arrange
+		await WriteForecastFileAsync(SampleJson);
+
+		// Act
+		var response = await _client.GetAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		result.GetProperty("json").GetString().ShouldBe(SampleJson);
+		result.GetProperty("fileName").GetString().ShouldBe(TestFileName);
+		result.GetProperty("source").GetString().ShouldBe("file");
+	}
+
+	[Fact]
+	public async Task GetForecast_PersistsToWorkSession_WhenFileFound()
+	{
+		// Arrange
+		await WriteForecastFileAsync(SampleJson);
+		await _client.GetAsync($"/api/forecast?date={TestDate}");
+		File.Delete(Path.Combine(_forecastDir, TestFileName));
+
+		// Act — file is gone, so a 200 can only come from the database
+		var response = await _client.GetAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		result.GetProperty("json").GetString().ShouldBe(SampleJson);
+		result.GetProperty("source").GetString().ShouldBe("database");
+	}
+
+	[Fact]
+	public async Task GetForecast_CreatesWorkSessionRow_WhenNoneExists()
+	{
+		// Arrange
+		await WriteForecastFileAsync(SampleJson);
+
+		// Act
+		await _client.GetAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		var sessionResponse = await _client.GetAsync($"/api/work-sessions?date={TestDate}");
+		sessionResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var session = await sessionResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		session.GetProperty("calendarForecastJson").GetString().ShouldBe(SampleJson);
+	}
+
+	[Fact]
+	public async Task GetForecast_ReturnsStoredJson_WhenAlreadyInDatabase()
+	{
+		// Arrange — seed via upload, no file on disk
+		await _client.PostAsJsonAsync($"/api/forecast?date={TestDate}", new { Json = SampleJson });
+
+		// Act
+		var response = await _client.GetAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		result.GetProperty("json").GetString().ShouldBe(SampleJson);
+		result.GetProperty("source").GetString().ShouldBe("database");
+	}
+
+	[Fact]
+	public async Task GetForecast_ReturnsNotFound_WhenNoFileAndNoDbValue()
+	{
+		// Act
+		var response = await _client.GetAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+	}
+
+	[Fact]
+	public async Task GetForecast_ReturnsProblem_WhenFileContainsInvalidJson()
+	{
+		// Arrange
+		await WriteForecastFileAsync("{ not json");
+
+		// Act
+		var response = await _client.GetAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+
+		// Nothing persisted — the work session row was never created
+		var sessionResponse = await _client.GetAsync($"/api/work-sessions?date={TestDate}");
+		sessionResponse.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+	}
+
+	[Fact]
+	public async Task PostForecast_StoresJson_WhenBodyIsValid()
+	{
+		// Act
+		var response = await _client.PostAsJsonAsync($"/api/forecast?date={TestDate}", new { Json = SampleJson });
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		result.GetProperty("json").GetString().ShouldBe(SampleJson);
+		result.GetProperty("source").GetString().ShouldBe("upload");
+
+		var getResponse = await _client.GetAsync($"/api/forecast?date={TestDate}");
+		getResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+	}
+
+	[Fact]
+	public async Task PostForecast_OverwritesExisting_WhenForecastAlreadyStored()
+	{
+		// Arrange
+		await _client.PostAsJsonAsync($"/api/forecast?date={TestDate}", new { Json = SampleJson });
+		var updatedJson = """{"date":"2020-01-15","meetings":{"count":5,"totalHours":4.0}}""";
+
+		// Act
+		var response = await _client.PostAsJsonAsync($"/api/forecast?date={TestDate}", new { Json = updatedJson });
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var getResponse = await _client.GetAsync($"/api/forecast?date={TestDate}");
+		var result = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		result.GetProperty("json").GetString().ShouldBe(updatedJson);
+	}
+
+	[Fact]
+	public async Task PostForecast_ReturnsProblem_WhenJsonInvalid()
+	{
+		// Act
+		var response = await _client.PostAsJsonAsync($"/api/forecast?date={TestDate}", new { Json = "{ not json" });
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+	}
+
+	[Fact]
+	public async Task DeleteForecast_ClearsColumnOnly_WhenForecastStored()
+	{
+		// Arrange
+		await _client.PostAsJsonAsync($"/api/forecast?date={TestDate}", new { Json = SampleJson });
+
+		// Act
+		var response = await _client.DeleteAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+		var getResponse = await _client.GetAsync($"/api/forecast?date={TestDate}");
+		getResponse.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+
+		// The work session row itself survives with the column cleared
+		var sessionResponse = await _client.GetAsync($"/api/work-sessions?date={TestDate}");
+		sessionResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var session = await sessionResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		session.GetProperty("calendarForecastJson").ValueKind.ShouldBe(JsonValueKind.Null);
+	}
+
+	[Fact]
+	public async Task DeleteForecast_ReturnsNoContent_WhenNoRowExists()
+	{
+		// Act
+		var response = await _client.DeleteAsync($"/api/forecast?date={TestDate}");
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+	}
+}

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -248,6 +248,85 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 	}
 
 	[Fact]
+	public async Task GenerateStandup_IncludesForecastInPrompt_WhenForecastStored()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		var forecastJson = """{"date":"2020-01-15","syncMeetings":["Ali / Jared"],"upcomingPTO":[]}""";
+		await _client.PostAsJsonAsync("/api/forecast?date=2020-01-15", new { Json = forecastJson });
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Forecast prompt item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldContain("Daily calendar forecast:");
+		userMessage.ShouldContain("Ali / Jared");
+	}
+
+	[Fact]
+	public async Task GenerateStandup_OmitsForecastSection_WhenNoForecastStored()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "No forecast item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldNotContain("Daily calendar forecast");
+	}
+
+	[Fact]
+	public async Task GenerateStandup_OmitsForecast_WhenWeeklyCommandType()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		var forecastJson = """{"date":"2020-01-15","syncMeetings":["Ali / Jared"],"upcomingPTO":[]}""";
+		await _client.PostAsJsonAsync("/api/forecast?date=2020-01-15", new { Json = forecastJson });
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Weekly forecast item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15&commandType=weekly", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldNotContain("Daily calendar forecast");
+	}
+
+	[Fact]
 	public async Task GetStandup_ReturnsEntryForSpecificDate_WhenMultipleDatesExist()
 	{
 		// Arrange: save standups for two different dates

--- a/api/tests/StandupPromptTests.cs
+++ b/api/tests/StandupPromptTests.cs
@@ -88,4 +88,44 @@ public class StandupPromptTests
 		message.ShouldContain("Learning queue items consumed this week");
 		message.ShouldContain(learningJson);
 	}
+
+	[Fact]
+	public void BuildUserMessage_AppendsForecastSection_WhenForecastProvided()
+	{
+		var workJson = """[{"id":1,"title":"Test"}]""";
+		var forecastJson = """{"syncMeetings":["Ali / Jared"],"upcomingPTO":[]}""";
+
+		var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-07", "2026-04-06", null, forecastJson);
+
+		message.ShouldContain("Daily calendar forecast:");
+		message.ShouldContain(forecastJson);
+	}
+
+	[Fact]
+	public void BuildUserMessage_OmitsForecastSection_WhenForecastNull()
+	{
+		var workJson = """[{"id":1,"title":"Test"}]""";
+
+		var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-07", "2026-04-06");
+
+		message.ShouldNotContain("Daily calendar forecast");
+	}
+
+	[Fact]
+	public void GetSystemPrompt_MentionsUpcomingPTO_WhenMidWeek()
+	{
+		var prompt = StandupPrompts.GetSystemPrompt(DayOfWeek.Tuesday);
+
+		prompt.ShouldContain("upcomingPTO");
+		prompt.ShouldContain("syncMeetings");
+	}
+
+	[Fact]
+	public void GetSystemPrompt_MentionsUpcomingPTO_WhenFriday()
+	{
+		var prompt = StandupPrompts.GetSystemPrompt(DayOfWeek.Friday);
+
+		prompt.ShouldContain("upcomingPTO");
+		prompt.ShouldContain("syncMeetings");
+	}
 }

--- a/web/src/components/FocusTimeline.spec.ts
+++ b/web/src/components/FocusTimeline.spec.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import FocusTimeline from './FocusTimeline.vue'
+import type { ForecastFocusBlock } from '@/types'
+
+const WINDOW = '08:00-17:00 ET'
+
+function mountComponent(blocks: ForecastFocusBlock[], recommendedLunch: string | null = null) {
+  return mount(FocusTimeline, {
+    props: { blocks, recommendedLunch, workdayWindow: WINDOW },
+  })
+}
+
+describe('FocusTimeline', () => {
+  it('FocusTimeline_RendersEighteenCells_WhenWindowIsEightToFive', () => {
+    // Arrange / Act
+    const wrapper = mountComponent([])
+
+    // Assert
+    expect(wrapper.findAll('[data-testid="timeline-cell"]')).toHaveLength(18)
+  })
+
+  it('FocusTimeline_MarksFocusSegments_WhenBlocksProvided', () => {
+    // Arrange / Act — 08:30-10:00 spans three full half-hour cells
+    const wrapper = mountComponent([
+      { startTime: '08:30 ET', endTime: '10:00 ET', duration: '90 min' },
+    ])
+
+    // Assert
+    const focusSegments = wrapper.findAll('[data-kind="focus"]')
+    expect(focusSegments).toHaveLength(3)
+    focusSegments.forEach(seg => {
+      expect(seg.attributes('style')).toContain('width: 100%')
+    })
+  })
+
+  it('FocusTimeline_MarksLunchSegments_WhenLunchProvided', () => {
+    // Arrange / Act
+    const wrapper = mountComponent([], '11:30-12:00 ET')
+
+    // Assert
+    const lunchSegments = wrapper.findAll('[data-kind="lunch"]')
+    expect(lunchSegments).toHaveLength(1)
+    expect(lunchSegments[0]!.attributes('style')).toContain('width: 100%')
+  })
+
+  it('FocusTimeline_RendersPartialSegment_WhenBlockEndsMidCell', () => {
+    // Arrange / Act — a 40-min block: full first cell + 10 min (33%) of the second
+    const wrapper = mountComponent([
+      { startTime: '08:30 ET', endTime: '09:10 ET', duration: '40 min' },
+    ])
+
+    // Assert
+    const focusSegments = wrapper.findAll('[data-kind="focus"]')
+    expect(focusSegments).toHaveLength(2)
+    const partialWidth = parseFloat(
+      focusSegments[1]!.attributes('style')!.match(/width:\s*([\d.]+)%/)![1]!,
+    )
+    expect(partialWidth).toBeCloseTo(33.33, 1)
+  })
+})

--- a/web/src/components/FocusTimeline.vue
+++ b/web/src/components/FocusTimeline.vue
@@ -93,7 +93,7 @@ const hourTicks = computed(() => {
           v-for="(seg, j) in cell.segments"
           :key="j"
           class="absolute inset-y-0"
-          :class="seg.kind === 'lunch' ? 'bg-accent' : 'bg-primary'"
+          :class="seg.kind === 'lunch' ? 'bg-lunch' : 'bg-primary'"
           :style="{ left: `${seg.leftPct}%`, width: `${seg.widthPct}%` }"
           :data-kind="seg.kind"
         />

--- a/web/src/components/FocusTimeline.vue
+++ b/web/src/components/FocusTimeline.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ForecastFocusBlock } from '@/types'
+import { parseClock, parseWindow } from '@/utils/forecast'
+
+const { blocks, recommendedLunch = null, workdayWindow } = defineProps<{
+  blocks: ForecastFocusBlock[]
+  recommendedLunch?: string | null
+  workdayWindow: string
+}>()
+
+type MinuteKind = 'open' | 'focus' | 'lunch'
+interface CellSegment {
+  kind: 'focus' | 'lunch'
+  leftPct: number
+  widthPct: number
+}
+interface Cell {
+  segments: CellSegment[]
+  fullyOpen: boolean
+}
+
+const CELL_MINUTES = 30
+
+const window_ = computed(() => parseWindow(workdayWindow))
+
+// Minute-resolution paint: focus first, lunch wins overlaps. Grouping into
+// 30-min cells afterwards means a 40-min block naturally half-fills its
+// second cell.
+const cells = computed<Cell[]>(() => {
+  const { startMin, endMin } = window_.value
+  const totalMinutes = endMin - startMin
+  const minuteKind: MinuteKind[] = Array(totalMinutes).fill('open')
+
+  const paint = (start: number | null, end: number | null, kind: MinuteKind) => {
+    if (start === null || end === null) return
+    const s = Math.max(0, start - startMin)
+    const e = Math.min(totalMinutes, end - startMin)
+    for (let i = s; i < e; i++) minuteKind[i] = kind
+  }
+
+  blocks.forEach(b => paint(parseClock(b.startTime), parseClock(b.endTime), 'focus'))
+
+  if (recommendedLunch) {
+    const [a, b] = recommendedLunch.split('-')
+    paint(parseClock(a ?? ''), parseClock(b ?? ''), 'lunch')
+  }
+
+  const result: Cell[] = []
+  for (let c = 0; c < totalMinutes; c += CELL_MINUTES) {
+    const cellMinutes = minuteKind.slice(c, c + CELL_MINUTES)
+    const segments: CellSegment[] = []
+    let i = 0
+    while (i < cellMinutes.length) {
+      const kind = cellMinutes[i]!
+      let j = i
+      while (j < cellMinutes.length && cellMinutes[j] === kind) j++
+      if (kind !== 'open') {
+        segments.push({
+          kind,
+          leftPct: (i / cellMinutes.length) * 100,
+          widthPct: ((j - i) / cellMinutes.length) * 100,
+        })
+      }
+      i = j
+    }
+    result.push({ segments, fullyOpen: segments.length === 0 })
+  }
+  return result
+})
+
+const hourTicks = computed(() => {
+  const { startMin, endMin } = window_.value
+  const ticks: string[] = []
+  for (let h = Math.floor(startMin / 60); h <= Math.ceil(endMin / 60); h++) {
+    ticks.push(String(h).padStart(2, '0'))
+  }
+  return ticks
+})
+</script>
+
+<template>
+  <div>
+    <div class="flex gap-0.5">
+      <div
+        v-for="(cell, i) in cells"
+        :key="i"
+        class="relative flex-1 h-6 border"
+        :class="cell.fullyOpen ? 'border-border' : 'border-transparent'"
+        data-testid="timeline-cell"
+      >
+        <div
+          v-for="(seg, j) in cell.segments"
+          :key="j"
+          class="absolute inset-y-0"
+          :class="seg.kind === 'lunch' ? 'bg-accent' : 'bg-primary'"
+          :style="{ left: `${seg.leftPct}%`, width: `${seg.widthPct}%` }"
+          :data-kind="seg.kind"
+        />
+      </div>
+    </div>
+    <div class="flex justify-between mt-1 text-[10px] text-muted-foreground tabular-nums">
+      <span v-for="tick in hourTicks" :key="tick">{{ tick }}</span>
+    </div>
+  </div>
+</template>

--- a/web/src/components/ForecastLoader.spec.ts
+++ b/web/src/components/ForecastLoader.spec.ts
@@ -1,0 +1,63 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import ForecastLoader from './ForecastLoader.vue'
+import type { ForecastStatus } from '@/types'
+
+function mountComponent(props: { status: ForecastStatus; fileName?: string | null; error?: string | null }) {
+  return mount(ForecastLoader, { props })
+}
+
+describe('ForecastLoader', () => {
+  it('ForecastLoader_ShowsScanning_WhenStatusLoading', () => {
+    // Arrange / Act
+    const wrapper = mountComponent({ status: 'loading' })
+
+    // Assert
+    expect(wrapper.get('[data-testid="forecast-scanning"]').text()).toContain('scanning local filesystem')
+  })
+
+  it('ForecastLoader_ShowsFileNameAndUnload_WhenStatusLoaded', () => {
+    // Arrange / Act
+    const wrapper = mountComponent({ status: 'loaded', fileName: 'daily-forecast-2026-07-14.json' })
+
+    // Assert
+    expect(wrapper.get('[data-testid="forecast-filename"]').text()).toBe('daily-forecast-2026-07-14.json')
+    expect(wrapper.find('[data-testid="forecast-unload"]').exists()).toBe(true)
+  })
+
+  it('ForecastLoader_ShowsLocateButton_WhenStatusMissing', () => {
+    // Arrange / Act
+    const wrapper = mountComponent({ status: 'missing' })
+
+    // Assert
+    expect(wrapper.get('[data-testid="forecast-missing"]').text()).toContain('no forecast file found')
+    expect(wrapper.find('[data-testid="forecast-pick"]').exists()).toBe(true)
+  })
+
+  it('ForecastLoader_EmitsUnload_WhenUnloadClicked', async () => {
+    // Arrange
+    const wrapper = mountComponent({ status: 'loaded', fileName: 'daily-forecast-2026-07-14.json' })
+
+    // Act
+    await wrapper.get('[data-testid="forecast-unload"]').trigger('click')
+
+    // Assert
+    expect(wrapper.emitted('unload')).toBeTruthy()
+  })
+
+  it('ForecastLoader_EmitsPickWithContent_WhenFileSelected', async () => {
+    // Arrange
+    const wrapper = mountComponent({ status: 'missing' })
+    const content = '{"date":"2026-07-14"}'
+    const file = new File([content], 'picked.json', { type: 'application/json' })
+    const input = wrapper.get('[data-testid="forecast-file-input"]')
+    Object.defineProperty(input.element, 'files', { value: [file] })
+
+    // Act
+    await input.trigger('change')
+    await flushPromises()
+
+    // Assert — FileReader completes on the event loop, not the microtask queue
+    await vi.waitFor(() => expect(wrapper.emitted('pick')).toBeTruthy())
+    expect(wrapper.emitted('pick')![0]).toEqual([content, 'picked.json'])
+  })
+})

--- a/web/src/components/ForecastLoader.spec.ts
+++ b/web/src/components/ForecastLoader.spec.ts
@@ -33,6 +33,16 @@ describe('ForecastLoader', () => {
     expect(wrapper.find('[data-testid="forecast-pick"]').exists()).toBe(true)
   })
 
+  it('ForecastLoader_ShowsErrorMessage_WhenStatusError', () => {
+    // Arrange / Act
+    const wrapper = mountComponent({ status: 'error', error: "'bad.json' is not valid JSON" })
+
+    // Assert — the real error is surfaced, not the misleading "not found" message
+    expect(wrapper.get('[data-testid="forecast-error"]').text()).toContain('is not valid JSON')
+    expect(wrapper.find('[data-testid="forecast-missing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="forecast-pick"]').exists()).toBe(true)
+  })
+
   it('ForecastLoader_EmitsUnload_WhenUnloadClicked', async () => {
     // Arrange
     const wrapper = mountComponent({ status: 'loaded', fileName: 'daily-forecast-2026-07-14.json' })

--- a/web/src/components/ForecastLoader.vue
+++ b/web/src/components/ForecastLoader.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ForecastStatus } from '@/types'
+
+const { status, fileName = null, error = null } = defineProps<{
+  status: ForecastStatus
+  fileName?: string | null
+  error?: string | null
+}>()
+
+const emit = defineEmits<{
+  pick: [content: string, name: string]
+  unload: []
+}>()
+
+const fileInputRef = ref<HTMLInputElement | null>(null)
+
+function readFileText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(file)
+  })
+}
+
+async function onFileChange(e: Event) {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  const content = await readFileText(file)
+  emit('pick', content, file.name)
+  input.value = ''
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-3 text-sm flex-wrap" data-testid="forecast-loader">
+    <span class="text-accent">&#9656;</span>
+    <span class="text-muted-foreground text-xs uppercase tracking-wider">forecast</span>
+
+    <span v-if="status === 'loading'" class="text-muted-foreground" data-testid="forecast-scanning">
+      scanning local filesystem<span class="inline-block w-2 bg-accent animate-blink ml-0.5">&nbsp;</span>
+    </span>
+
+    <span v-else-if="status === 'loaded'" class="inline-flex items-center gap-2 flex-1 min-w-0">
+      <span class="text-primary font-bold">&#10003; loaded</span>
+      <span class="text-muted-foreground">daily forecast</span>
+      <code
+        class="border border-border bg-secondary px-1.5 text-xs text-foreground"
+        data-testid="forecast-filename"
+      >{{ fileName }}</code>
+      <button
+        class="ml-auto text-muted-foreground hover:text-destructive text-xs"
+        title="Unload this forecast"
+        data-testid="forecast-unload"
+        @click="emit('unload')"
+      >
+        &#10005;
+      </button>
+    </span>
+
+    <span v-else class="inline-flex items-center gap-3 flex-wrap">
+      <span class="text-destructive" data-testid="forecast-missing">&#9888; no forecast file found for today</span>
+      <button
+        class="text-muted-foreground hover:text-primary text-xs"
+        data-testid="forecast-pick"
+        @click="fileInputRef?.click()"
+      >
+        [&#8981; locate forecast file&hellip;]
+      </button>
+      <input
+        ref="fileInputRef"
+        type="file"
+        accept=".json,application/json"
+        class="hidden"
+        data-testid="forecast-file-input"
+        @change="onFileChange"
+      />
+      <span v-if="error" class="text-destructive text-xs" data-testid="forecast-error">
+        <span class="text-accent">ERR:</span> {{ error }}
+      </span>
+    </span>
+  </div>
+</template>

--- a/web/src/components/ForecastLoader.vue
+++ b/web/src/components/ForecastLoader.vue
@@ -61,7 +61,10 @@ async function onFileChange(e: Event) {
     </span>
 
     <span v-else class="inline-flex items-center gap-3 flex-wrap">
-      <span class="text-destructive" data-testid="forecast-missing">&#9888; no forecast file found for today</span>
+      <span v-if="status === 'error'" class="text-destructive" data-testid="forecast-error">
+        <span class="text-accent">ERR:</span> {{ error ?? 'failed to load forecast' }}
+      </span>
+      <span v-else class="text-destructive" data-testid="forecast-missing">&#9888; no forecast file found for today</span>
       <button
         class="text-muted-foreground hover:text-primary text-xs"
         data-testid="forecast-pick"
@@ -77,9 +80,6 @@ async function onFileChange(e: Event) {
         data-testid="forecast-file-input"
         @change="onFileChange"
       />
-      <span v-if="error" class="text-destructive text-xs" data-testid="forecast-error">
-        <span class="text-accent">ERR:</span> {{ error }}
-      </span>
     </span>
   </div>
 </template>

--- a/web/src/components/SolidBar.spec.ts
+++ b/web/src/components/SolidBar.spec.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils'
+import SolidBar from './SolidBar.vue'
+
+describe('SolidBar', () => {
+  it('SolidBar_SetsFillWidth_WhenValueProvided', () => {
+    // Arrange / Act
+    const wrapper = mount(SolidBar, {
+      props: { label: 'focus', value: 4.5, max: 9 },
+    })
+
+    // Assert
+    const fill = wrapper.get('[data-testid="solid-bar-fill"]')
+    expect(fill.attributes('style')).toContain('width: 50%')
+  })
+
+  it('SolidBar_RendersTargetPipe_WhenTargetProvided', () => {
+    // Arrange / Act
+    const wrapper = mount(SolidBar, {
+      props: { label: 'meet', value: 3.5, target: 2.5, max: 10 },
+    })
+
+    // Assert
+    const pipe = wrapper.get('[data-testid="solid-bar-target"]')
+    expect(pipe.attributes('style')).toContain('left: 25%')
+  })
+
+  it('SolidBar_OmitsTargetPipe_WhenTargetAbsent', () => {
+    // Arrange / Act
+    const wrapper = mount(SolidBar, {
+      props: { label: 'meet', value: 3.5, max: 10 },
+    })
+
+    // Assert
+    expect(wrapper.find('[data-testid="solid-bar-target"]').exists()).toBe(false)
+  })
+})

--- a/web/src/components/SolidBar.vue
+++ b/web/src/components/SolidBar.vue
@@ -17,8 +17,15 @@ const targetPct = computed(() =>
 
 <template>
   <div class="flex items-center gap-3 text-sm">
-    <span class="w-12 shrink-0 text-muted-foreground">{{ label }}</span>
-    <div class="relative flex-1 h-4 border border-border bg-background">
+    <span class="w-12 shrink-0 text-muted-foreground text-xs uppercase tracking-wider">{{ label }}</span>
+    <div
+      class="relative flex-1 h-4 border border-border"
+      :style="{
+        backgroundImage: 'radial-gradient(var(--color-muted-foreground) 0.8px, transparent 0.8px)',
+        backgroundSize: '5px 5px',
+        backgroundPosition: '0 center',
+      }"
+    >
       <div
         class="absolute inset-y-0 left-0 transition-all"
         :class="fillClass"

--- a/web/src/components/SolidBar.vue
+++ b/web/src/components/SolidBar.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const { label, value, target = null, max, meta = '', fillClass = 'bg-primary' } = defineProps<{
+  label: string
+  value: number
+  target?: number | null
+  max: number
+  meta?: string
+  fillClass?: string
+}>()
+
+const valuePct = computed(() => Math.max(0, Math.min(100, (value / max) * 100)))
+const targetPct = computed(() =>
+  target == null ? null : Math.max(0, Math.min(100, (target / max) * 100)))
+</script>
+
+<template>
+  <div class="flex items-center gap-3 text-sm">
+    <span class="w-12 shrink-0 text-muted-foreground">{{ label }}</span>
+    <div class="relative flex-1 h-4 border border-border bg-background">
+      <div
+        class="absolute inset-y-0 left-0 transition-all"
+        :class="fillClass"
+        :style="{ width: `${valuePct}%` }"
+        data-testid="solid-bar-fill"
+      />
+      <template v-if="targetPct !== null">
+        <div
+          class="absolute inset-y-0 w-[6px] -translate-x-1/2 bg-card"
+          :style="{ left: `${targetPct}%` }"
+        />
+        <div
+          class="absolute inset-y-0 w-[2px] -translate-x-1/2 bg-accent"
+          :style="{ left: `${targetPct}%` }"
+          data-testid="solid-bar-target"
+        />
+      </template>
+    </div>
+    <span class="w-24 shrink-0 text-right text-xs text-muted-foreground">{{ meta }}</span>
+  </div>
+</template>

--- a/web/src/components/StandupPlanningModal.spec.ts
+++ b/web/src/components/StandupPlanningModal.spec.ts
@@ -1,0 +1,254 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+import StandupPlanningModal from './StandupPlanningModal.vue'
+import type { Mock } from 'vitest'
+import type { WorkItem } from '@/types'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+// StandupTasksPanel reads the dailyTasks store — mock it with an empty day
+const mockItems = ref<WorkItem[]>([])
+vi.mock('@/stores/dailyTasks', () => ({
+  useDailyTasksStore: () => ({
+    items: mockItems,
+    currentDay: 2,
+    getTasksForDay: () => mockItems.value,
+  }),
+}))
+
+import client from '@/api/client'
+const clientGet = (client as any).get as Mock
+const clientPost = (client as any).post as Mock
+const clientDelete = (client as any).delete as Mock
+
+const forecastJson = JSON.stringify({
+  date: '2026-07-14',
+  dayOfWeek: 'Tuesday',
+  workdayWindow: '08:00-17:00 ET',
+  meetings: { count: 4, totalHours: 3.5 },
+  focusTime: {
+    count: 1,
+    totalHours: 1.5,
+    blocks: [{ startTime: '08:30 ET', endTime: '10:00 ET', duration: '90 min' }],
+  },
+  syncMeetings: ['Ali / Jared'],
+  recommendedLunch: '11:30-12:00 ET',
+  upcomingPTO: [],
+})
+
+const forecastResponse = {
+  json: forecastJson,
+  fileName: 'daily-forecast-2026-07-14.json',
+  source: 'file',
+}
+
+const savedMarkdown = '### Did you complete your One Thing yesterday?\nCrushed it.\n\n### What is your One Thing today?\nInsights work.'
+
+function mockEndpoints({ forecast = true, saved = false }: { forecast?: boolean; saved?: boolean } = {}) {
+  clientGet.mockImplementation((url: string) => {
+    if (url === '/api/forecast') {
+      return forecast
+        ? Promise.resolve(forecastResponse)
+        : Promise.reject({ response: { status: 404 } })
+    }
+    return saved
+      ? Promise.resolve({ markdown: savedMarkdown, date: '2026-07-14' })
+      : Promise.reject({ response: { status: 404 } })
+  })
+}
+
+function mountComponent(props: { isOpen?: boolean; weekOf?: string } = {}) {
+  return mount(StandupPlanningModal, {
+    props: {
+      isOpen: props.isOpen ?? true,
+      weekOf: props.weekOf ?? '2026-07-13',
+    },
+    attachTo: document.body,
+  })
+}
+
+function queryBody(selector: string) {
+  return document.body.querySelector(selector)
+}
+
+describe('StandupPlanningModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockItems.value = []
+    clientDelete.mockResolvedValue('')
+  })
+
+  it('StandupPlanningModal_DoesNotRender_WhenClosed', () => {
+    mockEndpoints()
+    const wrapper = mountComponent({ isOpen: false })
+
+    expect(queryBody('[data-testid="planning-modal-overlay"]')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_FetchesForecast_WhenOpened', async () => {
+    mockEndpoints()
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(clientGet).toHaveBeenCalledWith('/api/forecast', expect.anything())
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_HidesPanelsAndShowsOnlyExit_WhenForecastMissing', async () => {
+    mockEndpoints({ forecast: false })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(queryBody('[data-testid="no-forecast-placeholder"]')).not.toBeNull()
+    expect(queryBody('[data-testid="shape-panel"]')).toBeNull()
+    expect(queryBody('[data-testid="cmd-save"]')).toBeNull()
+    expect(queryBody('[data-testid="cmd-copy"]')).toBeNull()
+    expect(queryBody('[data-testid="cmd-exit"]')).not.toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_RendersShapeAndTasksPanels_WhenForecastLoaded', async () => {
+    mockEndpoints()
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(queryBody('[data-testid="forecast-filename"]')?.textContent).toBe('daily-forecast-2026-07-14.json')
+    expect(queryBody('[data-testid="shape-panel"]')).not.toBeNull()
+    expect(queryBody('[data-testid="tasks-panel"]')).not.toBeNull()
+    expect(queryBody('[data-testid="questions-panel"]')).not.toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_ShowsSavedSections_WhenSavedStandupExists', async () => {
+    mockEndpoints({ saved: true })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const content = queryBody('[data-testid="planning-modal-content"]')?.textContent ?? ''
+    expect(content).toContain('Crushed it')
+    expect(queryBody('[data-testid="generate-standup-btn"]')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_ShowsGenerateButton_WhenNoSavedStandup', async () => {
+    mockEndpoints()
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(queryBody('[data-testid="generate-standup-btn"]')).not.toBeNull()
+    expect(queryBody('[data-testid="planning-modal-content"]')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_GeneratesSections_WhenGenerateClicked', async () => {
+    mockEndpoints()
+    clientPost.mockResolvedValue({ markdown: savedMarkdown })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const generateBtn = queryBody('[data-testid="generate-standup-btn"]') as HTMLElement
+    generateBtn.click()
+    await flushPromises()
+
+    const generateCall = clientPost.mock.calls.find((call: any[]) => call[0] === '/api/standup/generate')
+    expect(generateCall).toBeTruthy()
+    expect(generateCall![2].params).toEqual({ weekOf: '2026-07-13', today: expect.any(String) })
+    const content = queryBody('[data-testid="planning-modal-content"]')?.textContent ?? ''
+    expect(content).toContain('Crushed it')
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_CopiesAnswer_WhenSectionCopyClicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    mockEndpoints({ saved: true })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const copyBtn = queryBody('[data-testid="copy-section-0"]') as HTMLElement
+    copyBtn.click()
+    await nextTick()
+
+    expect(writeText).toHaveBeenCalledWith('Crushed it.')
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_SavesMarkdown_WhenSavePressed', async () => {
+    mockEndpoints({ saved: true })
+    clientPost.mockResolvedValue({ markdown: '', date: '' })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const saveBtn = queryBody('[data-testid="cmd-save"]') as HTMLElement
+    saveBtn.click()
+    await nextTick()
+
+    const saveCall = clientPost.mock.calls.find((call: any[]) => call[0] === '/api/standup')
+    expect(saveCall).toBeTruthy()
+    expect(saveCall![1].commandType).toBe('standup')
+    expect(saveCall![1].markdown).toContain('### Did you complete your One Thing yesterday?')
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_UnloadsForecast_WhenUnloadClicked', async () => {
+    mockEndpoints()
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const unloadBtn = queryBody('[data-testid="forecast-unload"]') as HTMLElement
+    unloadBtn.click()
+    await flushPromises()
+
+    expect(clientDelete).toHaveBeenCalledWith('/api/forecast', expect.anything())
+    expect(queryBody('[data-testid="shape-panel"]')).toBeNull()
+    expect(queryBody('[data-testid="no-forecast-placeholder"]')).not.toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_EmitsClose_WhenEscapePressed', async () => {
+    mockEndpoints()
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+
+    wrapper.unmount()
+  })
+
+  it('StandupPlanningModal_IgnoresSaveShortcut_WhenForecastNotLoaded', async () => {
+    mockEndpoints({ forecast: false })
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }))
+    await flushPromises()
+
+    const saveCall = clientPost.mock.calls.find((call: any[]) => call[0] === '/api/standup')
+    expect(saveCall).toBeFalsy()
+
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/StandupPlanningModal.vue
+++ b/web/src/components/StandupPlanningModal.vue
@@ -273,7 +273,7 @@ onUnmounted(() => {
               <!-- Generate affordance -->
               <div v-else-if="sections.length === 0" class="flex items-center gap-3">
                 <button
-                  class="text-muted-foreground hover:text-primary text-sm"
+                  class="border border-accent text-accent hover:bg-accent hover:text-accent-foreground transition-colors text-sm px-4 py-1.5 tracking-wide"
                   data-testid="generate-standup-btn"
                   @click="generate"
                 >
@@ -289,13 +289,13 @@ onUnmounted(() => {
                 v-else
                 ref="contentRef"
                 contenteditable="true"
-                class="w-full bg-transparent text-foreground focus:outline-none leading-relaxed"
+                class="w-full bg-transparent text-foreground text-sm focus:outline-none leading-relaxed"
                 data-testid="planning-modal-content"
               >
-                <div v-for="(section, i) in sections" :key="i" class="mb-8">
+                <div v-for="(section, i) in sections" :key="i" class="mb-6">
                   <div class="flex items-start gap-2 group">
                     <div class="flex-1">
-                      <div class="text-accent text-lg font-bold">{{ section.question }}</div>
+                      <div class="text-accent font-bold">{{ section.question }}</div>
                       <div class="whitespace-pre-wrap mt-1" v-html="renderBold(section.answer)"></div>
                     </div>
                     <button

--- a/web/src/components/StandupPlanningModal.vue
+++ b/web/src/components/StandupPlanningModal.vue
@@ -1,0 +1,379 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import client from '@/api/client'
+import { getToday } from '@/utils/week'
+import { useForecastStore } from '@/stores/forecast'
+import ForecastLoader from '@/components/ForecastLoader.vue'
+import StandupShapePanel from '@/components/StandupShapePanel.vue'
+import StandupTasksPanel from '@/components/StandupTasksPanel.vue'
+
+const { isOpen, weekOf = '' } = defineProps<{
+  isOpen: boolean
+  weekOf?: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const forecastStore = useForecastStore()
+const forecastLoaded = computed(() => forecastStore.status === 'loaded')
+
+const contentRef = ref<HTMLDivElement | null>(null)
+const copied = ref(false)
+const loading = ref(false)
+const saveState = ref<'idle' | 'saving' | 'saved'>('idle')
+const error = ref<string | null>(null)
+const sections = ref<{ question: string; answer: string }[]>([])
+const copiedSection = ref<number | null>(null)
+const checkedSaved = ref(false)
+const dotIndex = ref(0)
+let dotInterval: ReturnType<typeof setInterval> | null = null
+
+function getContent(): string {
+  return contentRef.value?.innerText ?? ''
+}
+
+function sectionsToMarkdown(): string {
+  return sections.value
+    .map((s) => `### ${s.question}\n${s.answer}`)
+    .join('\n\n')
+}
+
+async function handleSave() {
+  const markdown = sectionsToMarkdown().trim()
+  if (!markdown || saveState.value === 'saving') return
+
+  saveState.value = 'saving'
+  try {
+    await client.post('/api/standup', {
+      markdown,
+      date: getToday(),
+      commandType: 'standup',
+    })
+    saveState.value = 'saved'
+    setTimeout(() => { saveState.value = 'idle' }, 3000)
+  } catch (e: any) {
+    error.value = e?.response?.data ?? e?.message ?? 'Save failed'
+    saveState.value = 'idle'
+  }
+}
+
+function handleCopyAll() {
+  navigator.clipboard.writeText(getContent())
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 1500)
+}
+
+function handleCopySection(index: number) {
+  const section = sections.value[index]
+  if (!section) return
+  navigator.clipboard.writeText(section.answer)
+  copiedSection.value = index
+  setTimeout(() => { copiedSection.value = null }, 1500)
+}
+
+function renderBold(text: string): string {
+  return text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+}
+
+function parseMarkdown(markdown: string): { question: string; answer: string }[] {
+  const blocks = markdown.split(/^###\s+/m).filter(Boolean)
+  return blocks.map((block) => {
+    const newline = block.indexOf('\n')
+    const question = newline >= 0 ? block.slice(0, newline).trim() : block.trim()
+    const answer = newline >= 0 ? block.slice(newline + 1).trim() : ''
+    return { question, answer }
+  })
+}
+
+function startDotAnimation() {
+  dotIndex.value = 0
+  dotInterval = setInterval(() => {
+    dotIndex.value = (dotIndex.value + 1) % 4
+  }, 300)
+}
+
+function stopDotAnimation() {
+  if (dotInterval) {
+    clearInterval(dotInterval)
+    dotInterval = null
+  }
+}
+
+async function loadSaved() {
+  try {
+    const data = await client.get('/api/standup', { params: { date: getToday(), commandType: 'standup' } }) as any
+    if (data?.markdown) {
+      sections.value = parseMarkdown(data.markdown)
+    }
+  } catch {
+    // 404 or error — no saved entry, the generate button stays visible
+  }
+  checkedSaved.value = true
+}
+
+async function generate() {
+  if (!weekOf) return
+
+  loading.value = true
+  error.value = null
+  sections.value = []
+  startDotAnimation()
+
+  try {
+    const params: Record<string, string> = { weekOf, today: getToday() }
+    const data = await client.post('/api/standup/generate', null, { params }) as any
+    const markdown = data?.markdown ?? ''
+    sections.value = parseMarkdown(markdown)
+  } catch (e: any) {
+    error.value = e?.response?.data ?? e?.message ?? 'Generation failed'
+  } finally {
+    loading.value = false
+    stopDotAnimation()
+    await nextTick()
+    placeCursorAtEnd()
+  }
+}
+
+function placeCursorAtEnd() {
+  if (!contentRef.value) return
+  contentRef.value.focus()
+  const range = document.createRange()
+  range.selectNodeContents(contentRef.value)
+  range.collapse(false)
+  const sel = window.getSelection()
+  sel?.removeAllRanges()
+  sel?.addRange(range)
+}
+
+async function handleOpen() {
+  await forecastStore.fetchToday()
+  if (forecastStore.status === 'loaded') {
+    await loadSaved()
+  }
+}
+
+function handlePick(content: string, name: string) {
+  forecastStore.upload(content, name).then(() => {
+    if (forecastStore.status === 'loaded' && !checkedSaved.value) {
+      loadSaved()
+    }
+  })
+}
+
+function handleUnload() {
+  forecastStore.unload()
+}
+
+watch(() => isOpen, (open) => {
+  if (open) {
+    handleOpen()
+  } else {
+    stopDotAnimation()
+    sections.value = []
+    error.value = null
+    loading.value = false
+    saveState.value = 'idle'
+    checkedSaved.value = false
+  }
+}, { immediate: true })
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (!isOpen) return
+
+  const key = e.key.toLowerCase()
+  const activeElement = document.activeElement
+  const isEditingContent = contentRef.value?.contains(activeElement) ?? false
+
+  if (!isEditingContent) {
+    if (key === 's' && forecastLoaded.value) {
+      e.preventDefault()
+      handleSave()
+    } else if (key === 'c' && forecastLoaded.value) {
+      e.preventDefault()
+      handleCopyAll()
+    } else if (key === 'r' && forecastLoaded.value && !loading.value && sections.value.length > 0) {
+      e.preventDefault()
+      generate()
+    } else if (key === 'e') {
+      e.preventDefault()
+      emit('close')
+    }
+  }
+
+  if (key === 'escape') {
+    e.preventDefault()
+    emit('close')
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeyDown)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeyDown)
+  stopDotAnimation()
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isOpen"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm"
+      data-testid="planning-modal-overlay"
+    >
+      <div class="w-[80vw] h-[80vh] bg-card border-4 border-double border-primary flex flex-col">
+        <!-- Title bar -->
+        <div class="border-b-4 border-double border-primary px-4 py-2 flex items-center justify-center">
+          <span class="text-primary font-bold tracking-wider" data-testid="planning-modal-title">// DAILY STANDUP</span>
+        </div>
+
+        <!-- Content area -->
+        <div class="flex-1 p-6 overflow-auto space-y-6">
+          <ForecastLoader
+            :status="forecastStore.status"
+            :file-name="forecastStore.fileName"
+            :error="forecastStore.error"
+            @pick="handlePick"
+            @unload="handleUnload"
+          />
+
+          <template v-if="forecastLoaded && forecastStore.forecast">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <StandupShapePanel :forecast="forecastStore.forecast" />
+              <StandupTasksPanel />
+            </div>
+
+            <!-- Standup questions -->
+            <div class="bg-card border border-border p-4" data-testid="questions-panel">
+              <div class="flex items-center gap-2 mb-3">
+                <span class="text-accent">&gt;&gt;&gt;</span>
+                <span class="text-muted-foreground text-xs uppercase tracking-wider">Standup Questions</span>
+                <span
+                  v-if="sections.length > 0"
+                  class="ml-auto text-muted-foreground text-xs"
+                >generated &middot; editable before save</span>
+              </div>
+
+              <!-- Loading state -->
+              <div v-if="loading" class="text-muted-foreground" data-testid="planning-modal-loading">
+                <span>Generating</span>
+                <span v-for="i in 3" :key="i" :class="dotIndex >= i ? 'text-accent' : 'text-muted-foreground/30'">.</span>
+                <span class="inline-block w-2 bg-accent animate-blink ml-0.5">&nbsp;</span>
+              </div>
+
+              <!-- Error state -->
+              <div v-else-if="error" class="text-destructive" data-testid="planning-modal-error">
+                <span class="text-accent">ERR:</span> {{ error }}
+              </div>
+
+              <!-- Generate affordance -->
+              <div v-else-if="sections.length === 0" class="flex items-center gap-3">
+                <button
+                  class="text-muted-foreground hover:text-primary text-sm"
+                  data-testid="generate-standup-btn"
+                  @click="generate"
+                >
+                  &#9656; generate standup
+                </button>
+                <span class="text-muted-foreground text-xs">
+                  drafts answers from today's tasks &amp; forecast PTO
+                </span>
+              </div>
+
+              <!-- Generated content -->
+              <div
+                v-else
+                ref="contentRef"
+                contenteditable="true"
+                class="w-full bg-transparent text-foreground focus:outline-none leading-relaxed"
+                data-testid="planning-modal-content"
+              >
+                <div v-for="(section, i) in sections" :key="i" class="mb-8">
+                  <div class="flex items-start gap-2 group">
+                    <div class="flex-1">
+                      <div class="text-accent text-lg font-bold">{{ section.question }}</div>
+                      <div class="whitespace-pre-wrap mt-1" v-html="renderBold(section.answer)"></div>
+                    </div>
+                    <button
+                      contenteditable="false"
+                      class="shrink-0 mt-1 text-muted-foreground hover:text-primary transition-colors opacity-0 group-hover:opacity-100"
+                      :data-testid="`copy-section-${i}`"
+                      @click.stop="handleCopySection(i)"
+                    >
+                      <span v-if="copiedSection === i" class="text-accent text-xs">copied!</span>
+                      <span v-else class="text-xs">[cp]</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <div
+            v-else-if="forecastStore.status !== 'loading'"
+            class="flex items-center justify-center py-16"
+          >
+            <span class="text-muted-foreground text-sm italic" data-testid="no-forecast-placeholder">
+              &lt;no forecast loaded&gt;
+            </span>
+          </div>
+        </div>
+
+        <!-- Action bar -->
+        <div class="border-t-4 border-double border-primary px-4 py-3 flex items-center justify-center gap-8">
+          <span class="animate-pulse text-accent">_</span>
+          <template v-if="forecastLoaded">
+            <button
+              data-testid="cmd-save"
+              class="hover:text-primary transition-colors"
+              :disabled="saveState === 'saving'"
+              @click="handleSave"
+            >
+              <span class="text-accent">[</span>
+              <span class="text-primary font-bold">S</span>
+              <span class="text-accent">]</span>
+              <span v-if="saveState === 'saving'" class="text-muted-foreground">aving...</span>
+              <span v-else-if="saveState === 'saved'" class="text-accent">aved!</span>
+              <span v-else class="text-muted-foreground">ave</span>
+            </button>
+            <button
+              data-testid="cmd-copy"
+              class="hover:text-primary transition-colors"
+              @click="handleCopyAll"
+            >
+              <span class="text-accent">[</span>
+              <span class="text-primary font-bold">C</span>
+              <span class="text-accent">]</span>
+              <span class="text-muted-foreground" data-testid="copy-label">{{ copied ? 'opied!' : 'opy All' }}</span>
+            </button>
+            <button
+              v-if="!loading && sections.length > 0"
+              data-testid="cmd-regenerate"
+              class="hover:text-primary transition-colors"
+              @click="generate"
+            >
+              <span class="text-accent">[</span>
+              <span class="text-primary font-bold">R</span>
+              <span class="text-accent">]</span>
+              <span class="text-muted-foreground">egenerate</span>
+            </button>
+          </template>
+          <button
+            data-testid="cmd-exit"
+            class="hover:text-primary transition-colors"
+            @click="$emit('close')"
+          >
+            <span class="text-accent">[</span>
+            <span class="text-primary font-bold">E</span>
+            <span class="text-accent">]</span>
+            <span class="text-muted-foreground">xit</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/web/src/components/StandupShapePanel.vue
+++ b/web/src/components/StandupShapePanel.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DailyForecast } from '@/types'
+import { fmtHrs, parseWindow } from '@/utils/forecast'
+import SolidBar from '@/components/SolidBar.vue'
+import FocusTimeline from '@/components/FocusTimeline.vue'
+
+const { forecast } = defineProps<{
+  forecast: DailyForecast
+}>()
+
+const targets = computed(() => forecast.targets ?? { meetingHours: 2.5, focusHours: 4.0 })
+
+const max = computed(() => {
+  const { startMin, endMin } = parseWindow(forecast.workdayWindow)
+  const workHours = (endMin - startMin) / 60
+  return Math.max(
+    workHours,
+    forecast.meetings.totalHours,
+    forecast.focusTime.totalHours,
+    targets.value.meetingHours,
+    targets.value.focusHours,
+  )
+})
+</script>
+
+<template>
+  <div class="bg-card border border-border p-4" data-testid="shape-panel">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-accent">&gt;&gt;&gt;</span>
+      <span class="text-muted-foreground text-xs uppercase tracking-wider">Today's Shape</span>
+      <span class="ml-auto text-muted-foreground text-xs">{{ forecast.workdayWindow }}</span>
+    </div>
+
+    <div class="flex flex-col gap-3">
+      <SolidBar
+        label="meet"
+        :value="forecast.meetings.totalHours"
+        :target="targets.meetingHours"
+        :max="max"
+        :meta="`${fmtHrs(forecast.meetings.totalHours)} &middot; ${forecast.meetings.count}`"
+        fill-class="bg-muted-foreground"
+        data-testid="meet-bar"
+      />
+      <SolidBar
+        label="focus"
+        :value="forecast.focusTime.totalHours"
+        :target="targets.focusHours"
+        :max="max"
+        :meta="`${fmtHrs(forecast.focusTime.totalHours)} &middot; ${forecast.focusTime.count}`"
+        fill-class="bg-primary"
+        data-testid="focus-bar"
+      />
+      <div class="text-xs text-muted-foreground">
+        <span class="text-accent">&#9474;</span> = target line
+      </div>
+    </div>
+
+    <div class="border-t border-border mt-4 pt-3">
+      <div class="text-xs text-muted-foreground mb-2 tracking-wide">
+        focus blocks across the day &middot; 30-min increments
+        <span v-if="forecast.recommendedLunch">
+          &middot; lunch <span class="text-accent">{{ forecast.recommendedLunch }}</span>
+        </span>
+      </div>
+      <FocusTimeline
+        :blocks="forecast.focusTime.blocks"
+        :recommended-lunch="forecast.recommendedLunch"
+        :workday-window="forecast.workdayWindow"
+      />
+      <div class="flex gap-4 mt-3 text-xs text-muted-foreground">
+        <span class="inline-flex items-center gap-1.5">
+          <i class="inline-block w-3 h-3 bg-primary" /> focus
+        </span>
+        <span class="inline-flex items-center gap-1.5">
+          <i class="inline-block w-3 h-3 bg-accent" /> lunch
+        </span>
+        <span class="inline-flex items-center gap-1.5">
+          <i class="inline-block w-3 h-3 border border-border" /> open / meetings
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/StandupShapePanel.vue
+++ b/web/src/components/StandupShapePanel.vue
@@ -59,7 +59,7 @@ const max = computed(() => {
       <div class="text-xs text-muted-foreground mb-2 tracking-wide">
         focus blocks across the day &middot; 30-min increments
         <span v-if="forecast.recommendedLunch">
-          &middot; lunch <span class="text-accent">{{ forecast.recommendedLunch }}</span>
+          &middot; lunch <span class="text-lunch">{{ forecast.recommendedLunch }}</span>
         </span>
       </div>
       <FocusTimeline
@@ -72,7 +72,7 @@ const max = computed(() => {
           <i class="inline-block w-3 h-3 bg-primary" /> focus
         </span>
         <span class="inline-flex items-center gap-1.5">
-          <i class="inline-block w-3 h-3 bg-accent" /> lunch
+          <i class="inline-block w-3 h-3 bg-lunch" /> lunch
         </span>
         <span class="inline-flex items-center gap-1.5">
           <i class="inline-block w-3 h-3 border border-border" /> open / meetings

--- a/web/src/components/StandupShapePanel.vue
+++ b/web/src/components/StandupShapePanel.vue
@@ -26,10 +26,9 @@ const max = computed(() => {
 
 <template>
   <div class="bg-card border border-border p-4" data-testid="shape-panel">
-    <div class="flex items-center gap-2 mb-3">
-      <span class="text-accent">&gt;&gt;&gt;</span>
-      <span class="text-muted-foreground text-xs uppercase tracking-wider">Today's Shape</span>
-      <span class="ml-auto text-muted-foreground text-xs">{{ forecast.workdayWindow }}</span>
+    <div class="flex items-baseline justify-between border-b border-dashed border-border pb-2 mb-4">
+      <span class="text-accent font-bold uppercase tracking-wider">Today's Shape</span>
+      <span class="text-muted-foreground text-xs">{{ forecast.workdayWindow }}</span>
     </div>
 
     <div class="flex flex-col gap-3">
@@ -39,7 +38,7 @@ const max = computed(() => {
         :target="targets.meetingHours"
         :max="max"
         :meta="`${fmtHrs(forecast.meetings.totalHours)} &middot; ${forecast.meetings.count}`"
-        fill-class="bg-muted-foreground"
+        fill-class="bg-accent"
         data-testid="meet-bar"
       />
       <SolidBar

--- a/web/src/components/StandupTasksPanel.spec.ts
+++ b/web/src/components/StandupTasksPanel.spec.ts
@@ -1,0 +1,100 @@
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import StandupTasksPanel from './StandupTasksPanel.vue'
+import type { WorkItem } from '@/types'
+
+const TODAY_DATE = '2026-04-08'
+
+// Reactive store mock — shared across tests, reset in beforeEach
+const mockItems = ref<WorkItem[]>([])
+
+vi.mock('@/stores/dailyTasks', () => ({
+  useDailyTasksStore: () => ({
+    items: mockItems,
+    currentDay: 2,
+    getTasksForDay: () =>
+      mockItems.value
+        .filter(t => t.category === 'SmallThing' && t.date === TODAY_DATE)
+        .sort((a, b) => a.sortOrder - b.sortOrder),
+  }),
+}))
+
+let nextId = 1
+
+const createWorkItem = (overrides: Partial<WorkItem> = {}): WorkItem => ({
+  id: nextId++,
+  title: 'Test task',
+  category: 'SmallThing',
+  isDone: false,
+  sortOrder: 0,
+  date: TODAY_DATE,
+  weekOf: '2026-04-06',
+  originalDate: TODAY_DATE,
+  timesMoved: 0,
+  isSkipped: false,
+  ...overrides,
+})
+
+describe('StandupTasksPanel', () => {
+  beforeEach(() => {
+    mockItems.value = []
+    nextId = 1
+  })
+
+  it('StandupTasksPanel_RendersOneThingEmphasis_WhenTasksExist', () => {
+    // Arrange
+    mockItems.value = [
+      createWorkItem({ title: 'The one thing', sortOrder: 0 }),
+      createWorkItem({ title: 'Second task', sortOrder: 1 }),
+    ]
+
+    // Act
+    const wrapper = mount(StandupTasksPanel)
+
+    // Assert
+    const titles = wrapper.findAll('[data-testid="planning-task-title"]')
+    expect(titles).toHaveLength(2)
+    expect(titles[0]!.classes()).toContain('uppercase')
+    expect(titles[0]!.classes()).toContain('text-accent')
+    expect(titles[1]!.classes()).not.toContain('uppercase')
+    expect(wrapper.findAll('[data-testid="one-thing-badge"]')).toHaveLength(1)
+  })
+
+  it('StandupTasksPanel_ShowsCarryBadge_WhenTaskCarried', () => {
+    // Arrange — carried 2 days
+    mockItems.value = [
+      createWorkItem({ title: 'Carried task', originalDate: '2026-04-06', date: TODAY_DATE }),
+    ]
+
+    // Act
+    const wrapper = mount(StandupTasksPanel)
+
+    // Assert
+    const badge = wrapper.get('[data-testid="carry-badge"]')
+    expect(badge.text()).toContain('2d')
+  })
+
+  it('StandupTasksPanel_ShowsStrikethrough_WhenTaskDone', () => {
+    // Arrange
+    mockItems.value = [
+      createWorkItem({ title: 'First', sortOrder: 0 }),
+      createWorkItem({ title: 'Done task', sortOrder: 1, isDone: true }),
+    ]
+
+    // Act
+    const wrapper = mount(StandupTasksPanel)
+
+    // Assert
+    const titles = wrapper.findAll('[data-testid="planning-task-title"]')
+    expect(titles[1]!.classes()).toContain('line-through')
+  })
+
+  it('StandupTasksPanel_ShowsPlaceholder_WhenNoTasks', () => {
+    // Act
+    const wrapper = mount(StandupTasksPanel)
+
+    // Assert
+    expect(wrapper.text()).toContain('<no tasks for today>')
+    expect(wrapper.findAll('[data-testid="planning-task-row"]')).toHaveLength(0)
+  })
+})

--- a/web/src/components/StandupTasksPanel.vue
+++ b/web/src/components/StandupTasksPanel.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDailyTasksStore } from '@/stores/dailyTasks'
+import { getCarriedDays } from '@/utils/week'
+import type { WorkItem } from '@/types'
+
+const store = useDailyTasksStore()
+
+const tasks = computed(() => store.getTasksForDay(store.currentDay))
+
+function carriedDays(task: WorkItem): number {
+  return getCarriedDays(task.originalDate, task.date)
+}
+</script>
+
+<template>
+  <div class="bg-card border border-border p-4" data-testid="tasks-panel">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-accent">&gt;&gt;&gt;</span>
+      <span class="text-muted-foreground text-xs uppercase tracking-wider">Today's Tasks</span>
+      <span class="ml-auto text-muted-foreground text-xs">from main view &middot; read-only</span>
+    </div>
+
+    <div v-if="tasks.length === 0" class="text-muted-foreground text-sm italic">
+      &lt;no tasks for today&gt;
+    </div>
+
+    <div v-else class="flex flex-col gap-1.5">
+      <div
+        v-for="(task, taskIndex) in tasks"
+        :key="task.id"
+        class="flex items-baseline gap-2 text-sm"
+        data-testid="planning-task-row"
+      >
+        <span
+          :class="[
+            'flex-1 break-words',
+            taskIndex === 0 ? 'uppercase text-accent font-bold' : '',
+            task.isDone ? 'line-through text-muted-foreground' : taskIndex === 0 ? '' : 'text-foreground',
+          ]"
+          data-testid="planning-task-title"
+        >
+          {{ task.title }}
+        </span>
+        <span
+          v-if="taskIndex === 0"
+          class="flex-shrink-0 self-center text-[10.5px] leading-none whitespace-nowrap text-accent border border-accent/50 bg-accent/5 px-1.5 py-0.5"
+          data-testid="one-thing-badge"
+        >
+          one thing
+        </span>
+        <span
+          v-if="carriedDays(task) > 0"
+          class="flex-shrink-0 self-center text-[10.5px] leading-none whitespace-nowrap text-accent border border-accent/50 bg-accent/5 px-1.5 py-0.5"
+          :title="`carried ${carriedDays(task)} day${carriedDays(task) > 1 ? 's' : ''}`"
+          data-testid="carry-badge"
+        >
+          &#8635; {{ carriedDays(task) }}d
+        </span>
+      </div>
+    </div>
+
+    <div class="text-xs text-muted-foreground mt-3">
+      &#8635; carried over
+    </div>
+  </div>
+</template>

--- a/web/src/components/StandupTasksPanel.vue
+++ b/web/src/components/StandupTasksPanel.vue
@@ -15,10 +15,9 @@ function carriedDays(task: WorkItem): number {
 
 <template>
   <div class="bg-card border border-border p-4" data-testid="tasks-panel">
-    <div class="flex items-center gap-2 mb-3">
-      <span class="text-accent">&gt;&gt;&gt;</span>
-      <span class="text-muted-foreground text-xs uppercase tracking-wider">Today's Tasks</span>
-      <span class="ml-auto text-muted-foreground text-xs">from main view &middot; read-only</span>
+    <div class="flex items-baseline justify-between border-b border-dashed border-border pb-2 mb-4">
+      <span class="text-accent font-bold uppercase tracking-wider">Today's Tasks</span>
+      <span class="text-muted-foreground text-xs">from main view &middot; read-only</span>
     </div>
 
     <div v-if="tasks.length === 0" class="text-muted-foreground text-sm italic">

--- a/web/src/stores/forecast.spec.ts
+++ b/web/src/stores/forecast.spec.ts
@@ -92,7 +92,7 @@ describe('useForecastStore', () => {
 
     // Assert
     expect(mockPost).not.toHaveBeenCalled()
-    expect(store.status).toBe('missing')
+    expect(store.status).toBe('error')
     expect(store.error).toContain('bad.json')
   })
 

--- a/web/src/stores/forecast.spec.ts
+++ b/web/src/stores/forecast.spec.ts
@@ -1,0 +1,115 @@
+import { setActivePinia, createPinia } from 'pinia'
+import type { Mock } from 'vitest'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import client from '@/api/client'
+import { useForecastStore } from './forecast'
+import { getToday } from '@/utils/week'
+
+const mockGet = (client as any).get as Mock
+const mockPost = (client as any).post as Mock
+const mockDelete = (client as any).delete as Mock
+
+const forecastJson = '{"date":"2026-07-14","dayOfWeek":"Tuesday","workdayWindow":"08:00-17:00 ET"}'
+
+describe('useForecastStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchToday_SetsLoadedForecast_WhenApiReturnsJson', async () => {
+    // Arrange
+    mockGet.mockResolvedValue({ json: forecastJson, fileName: 'daily-forecast-2026-07-14.json', source: 'file' })
+    const store = useForecastStore()
+
+    // Act
+    await store.fetchToday()
+
+    // Assert
+    expect(mockGet).toHaveBeenCalledWith('/api/forecast', { params: { date: getToday() } })
+    expect(store.status).toBe('loaded')
+    expect(store.fileName).toBe('daily-forecast-2026-07-14.json')
+    expect(store.forecast?.date).toBe('2026-07-14')
+  })
+
+  it('fetchToday_SetsMissing_WhenApiReturns404', async () => {
+    // Arrange
+    mockGet.mockRejectedValue({ response: { status: 404 } })
+    const store = useForecastStore()
+
+    // Act
+    await store.fetchToday()
+
+    // Assert
+    expect(store.status).toBe('missing')
+    expect(store.forecast).toBeNull()
+    expect(store.error).toBeNull()
+  })
+
+  it('fetchToday_SetsError_WhenRequestFails', async () => {
+    // Arrange
+    mockGet.mockRejectedValue({ message: 'Network Error' })
+    const store = useForecastStore()
+
+    // Act
+    await store.fetchToday()
+
+    // Assert
+    expect(store.status).toBe('error')
+    expect(store.error).toBe('Network Error')
+  })
+
+  it('upload_PostsJsonAndSetsLoaded_WhenContentValid', async () => {
+    // Arrange
+    mockPost.mockResolvedValue({ json: forecastJson, fileName: 'daily-forecast-2026-07-14.json', source: 'upload' })
+    const store = useForecastStore()
+
+    // Act
+    await store.upload(forecastJson, 'my-forecast.json')
+
+    // Assert
+    expect(mockPost).toHaveBeenCalledWith('/api/forecast', { json: forecastJson }, { params: { date: getToday() } })
+    expect(store.status).toBe('loaded')
+    expect(store.fileName).toBe('my-forecast.json')
+    expect(store.forecast?.date).toBe('2026-07-14')
+  })
+
+  it('upload_SetsErrorWithoutPosting_WhenContentInvalidJson', async () => {
+    // Arrange
+    const store = useForecastStore()
+
+    // Act
+    await store.upload('{ not json', 'bad.json')
+
+    // Assert
+    expect(mockPost).not.toHaveBeenCalled()
+    expect(store.status).toBe('missing')
+    expect(store.error).toContain('bad.json')
+  })
+
+  it('unload_ClearsStateAndCallsDelete_WhenCalled', async () => {
+    // Arrange
+    mockGet.mockResolvedValue({ json: forecastJson, fileName: 'daily-forecast-2026-07-14.json', source: 'file' })
+    mockDelete.mockResolvedValue('')
+    const store = useForecastStore()
+    await store.fetchToday()
+
+    // Act
+    await store.unload()
+
+    // Assert
+    expect(mockDelete).toHaveBeenCalledWith('/api/forecast', { params: { date: getToday() } })
+    expect(store.status).toBe('missing')
+    expect(store.forecast).toBeNull()
+    expect(store.fileName).toBeNull()
+  })
+})

--- a/web/src/stores/forecast.ts
+++ b/web/src/stores/forecast.ts
@@ -1,0 +1,63 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import client from '@/api/client'
+import type { DailyForecast, ForecastStatus } from '@/types'
+import { getToday } from '@/utils/week'
+
+export const useForecastStore = defineStore('forecast', () => {
+  const forecast = ref<DailyForecast | null>(null)
+  const fileName = ref<string | null>(null)
+  const status = ref<ForecastStatus>('missing')
+  const error = ref<string | null>(null)
+
+  async function fetchToday() {
+    status.value = 'loading'
+    error.value = null
+    try {
+      const data = await client.get('/api/forecast', { params: { date: getToday() } }) as any
+      forecast.value = JSON.parse(data.json)
+      fileName.value = data.fileName
+      status.value = 'loaded'
+    } catch (e: any) {
+      forecast.value = null
+      fileName.value = null
+      if (e?.response?.status === 404) {
+        status.value = 'missing'
+      } else {
+        status.value = 'error'
+        error.value = e?.response?.data?.detail ?? e?.message ?? 'Failed to load forecast'
+      }
+    }
+  }
+
+  async function upload(content: string, name: string) {
+    let parsed: DailyForecast
+    try {
+      parsed = JSON.parse(content)
+    } catch {
+      error.value = `'${name}' is not valid JSON`
+      return
+    }
+
+    try {
+      await client.post('/api/forecast', { json: content }, { params: { date: getToday() } })
+      forecast.value = parsed
+      fileName.value = name
+      status.value = 'loaded'
+      error.value = null
+    } catch (e: any) {
+      status.value = 'error'
+      error.value = e?.response?.data?.detail ?? e?.message ?? 'Upload failed'
+    }
+  }
+
+  async function unload() {
+    await client.delete('/api/forecast', { params: { date: getToday() } })
+    forecast.value = null
+    fileName.value = null
+    status.value = 'missing'
+    error.value = null
+  }
+
+  return { forecast, fileName, status, error, fetchToday, upload, unload }
+})

--- a/web/src/stores/forecast.ts
+++ b/web/src/stores/forecast.ts
@@ -35,6 +35,7 @@ export const useForecastStore = defineStore('forecast', () => {
     try {
       parsed = JSON.parse(content)
     } catch {
+      status.value = 'error'
       error.value = `'${name}' is not valid JSON`
       return
     }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -17,6 +17,7 @@
   --muted-foreground: oklch(0.55 0.05 255);
   --accent: oklch(0.7 0.18 55);
   --accent-foreground: oklch(0.2 0.05 55);
+  --lunch: oklch(0.72 0.13 95);
   --success: oklch(0.50 0.09 155);
   --success-foreground: oklch(0.96 0.01 85);
   --destructive: oklch(0.55 0.2 25);
@@ -44,6 +45,7 @@
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+  --color-lunch: var(--lunch);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --color-destructive: var(--destructive);

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -45,4 +45,33 @@ export interface WorkSession {
   clockedOutAt: string | null
   createdAt: string
   reflections: WorkSessionReflections | null
+  calendarForecastJson?: string | null
 }
+
+export interface ForecastFocusBlock {
+  startTime: string
+  endTime: string
+  duration: string
+}
+
+export interface ForecastPto {
+  title: string
+  start: string
+  end: string
+  allDay: boolean
+  eventType: string
+}
+
+export interface DailyForecast {
+  date: string
+  dayOfWeek: string
+  workdayWindow: string
+  meetings: { count: number; totalHours: number }
+  focusTime: { count: number; totalHours: number; blocks: ForecastFocusBlock[] }
+  syncMeetings: string[]
+  recommendedLunch: string | null
+  upcomingPTO: ForecastPto[]
+  targets?: { meetingHours: number; focusHours: number }
+}
+
+export type ForecastStatus = 'loading' | 'loaded' | 'missing' | 'error'

--- a/web/src/utils/forecast.ts
+++ b/web/src/utils/forecast.ts
@@ -23,9 +23,3 @@ export function parseWindow(w: string): { startMin: number; endMin: number } {
     endMin: parseClock(parts[1] ?? '') ?? 1020,
   }
 }
-
-// ISO date/datetime pair -> "Jul 24 – Jul 30"
-export function formatPtoRange(start: string, end: string): string {
-  const f = (x: string) => new Date(x).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-  return `${f(start)} – ${f(end)}`
-}

--- a/web/src/utils/forecast.ts
+++ b/web/src/utils/forecast.ts
@@ -1,0 +1,31 @@
+// Pure helpers for daily calendar forecast data. Times are wall-clock — any
+// timezone suffix (" ET") is ignored, matching the forecast file contract.
+
+// 4.5 -> "4h 30m", 4 -> "4h"
+export function fmtHrs(h: number): string {
+  const hours = Math.floor(h)
+  const mins = Math.round((h - hours) * 60)
+  return mins ? `${hours}h ${String(mins).padStart(2, '0')}m` : `${hours}h`
+}
+
+// "08:30 ET" -> minutes since midnight
+export function parseClock(s: string): number | null {
+  const m = String(s).match(/(\d{1,2}):(\d{2})/)
+  if (!m) return null
+  return parseInt(m[1]!, 10) * 60 + parseInt(m[2]!, 10)
+}
+
+// "08:00-17:00 ET" -> { startMin, endMin }, defaulting to 8am-5pm
+export function parseWindow(w: string): { startMin: number; endMin: number } {
+  const parts = String(w).split('-')
+  return {
+    startMin: parseClock(parts[0] ?? '') ?? 480,
+    endMin: parseClock(parts[1] ?? '') ?? 1020,
+  }
+}
+
+// ISO date/datetime pair -> "Jul 24 – Jul 30"
+export function formatPtoRange(start: string, end: string): string {
+  const f = (x: string) => new Date(x).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return `${f(start)} – ${f(end)}`
+}

--- a/web/src/views/DailyBoard.vue
+++ b/web/src/views/DailyBoard.vue
@@ -16,6 +16,7 @@ import StatsPanel from '@/components/StatsPanel.vue'
 import ClockStatus from '@/components/ClockStatus.vue'
 import SlashCommandMenu from '@/components/SlashCommandMenu.vue'
 import CommandModal from '@/components/CommandModal.vue'
+import StandupPlanningModal from '@/components/StandupPlanningModal.vue'
 import EvaluateWeekModal from '@/components/EvaluateWeekModal.vue'
 import PunchModal from '@/components/PunchModal.vue'
 import PastWeekView from '@/components/PastWeekView.vue'
@@ -35,13 +36,8 @@ const currentWeekStart = getWeekStart()
 const selectedWeek = ref<string>(currentWeekStart)
 const isPastWeek = computed(() => selectedWeek.value !== currentWeekStart)
 
-const modalTitle = computed(() => {
-  switch (activeCommand.value) {
-    case 'standup': return '// DAILY STANDUP'
-    case 'weekly': return '// WEEKLY ROUNDUP'
-    default: return ''
-  }
-})
+const modalTitle = computed(() =>
+  activeCommand.value === 'weekly' ? '// WEEKLY ROUNDUP' : '')
 
 function handleCommand(type: CommandType) {
   activeCommand.value = type
@@ -153,8 +149,14 @@ onMounted(() => {
 
       <BigThing v-if="!isPastWeek" />
 
+      <StandupPlanningModal
+        :is-open="activeCommand === 'standup'"
+        :week-of="dailyTasks.weekOf"
+        @close="activeCommand = null"
+      />
+
       <CommandModal
-        :is-open="activeCommand === 'standup' || activeCommand === 'weekly'"
+        :is-open="activeCommand === 'weekly'"
         :title="modalTitle"
         :command-type="activeCommand"
         :week-of="dailyTasks.weekOf"


### PR DESCRIPTION
@
## What

Turns `/standup` into a multi-part **planning session**. A new `StandupPlanningModal` replaces `CommandModal` for `/standup` only — `/weekly` keeps `CommandModal` unchanged.

The modal loads a daily calendar forecast, visualizes the day, shows todays tasks read-only, and generates the standup Q&A with the forecast as AI context.

## Flow

1. **Forecast loader** — auto-discovers `daily-forecast-{date}.json` from `resources/calendar-forecasts` (path configurable via `CalendarForecasts:Directory`), persists it to the `WorkSessions` row, and shows `✓ loaded` + filename with an unload `✕`. If none is found, a file picker lets you locate one; upload overwrites, unload clears just that column.
2. **Todays Shape** — meeting/focus hours as bars against the 2.5h/4h targets (gold target pipes, dotted track), plus a 30-min-block timeline (8am–5pm) with half-fill support for partial blocks and the recommended lunch in a distinct gold.
3. **Todays Tasks** — read-only view of the daily work items: one-thing emphasis, carry-over `↻ Nd` badges, done strikethrough.
4. **Standup Q&A** — generation reuses the existing endpoint; per-answer copy and copy-all are kept. The stored forecast feeds the prompt so Q3 answers from `upcomingPTO` (e.g. "OOO Jul 24 – Jul 30") instead of "No", and Q2 folds in `syncMeetings`. Prose style and word caps unchanged; Monday stub left as-is.

## Backend

- New nullable `CalendarForecastJson` (text) column on `WorkSessions` (migration `AddCalendarForecastJsonToWorkSessions`).
- New `/api/forecast` GET/POST/DELETE endpoints; invalid JSON is rejected 422 and never persisted.
- Prompt updates in `StandupPrompts` (mid-week + Friday) to consume forecast `syncMeetings`/`upcomingPTO`.

## Design

- Panels match the prototype: bold accent headers with dashed underlines, dotted bar tracks, accent (gold) meet / primary (blue) focus split.
- New semantic `--lunch` token (muted mustard-gold) so the lunch block reads distinct from the bright `accent` used by target pipes and `>>>`. Documented in the design system.

## Tests

- **API:** 100/100 xUnit — forecast endpoints (file/db/upload/unload/invalid-json), generate-includes-forecast, prompt units.
- **Web:** 233/233 Vitest — 6 new spec files (forecast store, loader states, modal flow, tasks panel, timeline half-fill, solid bar).
- Verified end-to-end in the running Aspire app: forecast auto-load from disk, timeline geometry, live generation with real PTO/syncs, unload clearing only the column while preserving clock data, and re-discovery on reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@