### PR TITLE
feat(api): build standup prompts from precomputed context

### DIFF
--- a/api/src/Dtos/StandupContextDtos.cs
+++ b/api/src/Dtos/StandupContextDtos.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace DailyWork.Api.Dtos;
+
+internal record StandupItem(string Title, string Status);
+
+internal record StandupYesterday(StandupItem? OneThing, List<StandupItem> Others);
+
+internal record StandupToday(StandupItem? OneThing, List<string> AlsoOnDeck);
+
+internal record StandupPto(string Title, string? Start, string? End);
+
+internal record StandupContext(
+	string? WeeklyGoal,
+	StandupYesterday Yesterday,
+	StandupToday Today,
+	List<string> SyncMeetings,
+	[property: JsonPropertyName("upcomingPTO")] List<StandupPto> UpcomingPto);
+
+// Tolerant parse target for WorkSession.CalendarForecastJson — only the two fields
+// the standup prompt uses; unknown forecast fields are ignored, missing keys stay null.
+internal record StandupForecast(List<string>? SyncMeetings, List<StandupPto>? UpcomingPto);

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -8,6 +8,7 @@ using DailyWork.Api.Enums;
 using DailyWork.Api.Prompts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
 
 namespace DailyWork.Api.Endpoints;
 
@@ -120,6 +121,7 @@ internal static class StandupEndpoints
 			AppDbContext db,
 			IDateTimeProvider dateTime,
 			IChatCompletionService? chatService,
+			ILoggerFactory loggerFactory,
 			string? weekOf,
 			string? commandType,
 			DateOnly? today) =>
@@ -151,12 +153,22 @@ internal static class StandupEndpoints
 			if (items.Count == 0)
 				return Results.BadRequest("No work items found for the specified week.");
 
-			// For Monday prompts or weekly command, also fetch previous week's items
 			var dayOfWeek = todayDate.DayOfWeek;
 			var useWeeklyPrompt = string.Equals(commandType, "weekly", StringComparison.OrdinalIgnoreCase);
+			// Monday daily standups keep the legacy raw-items message until the Monday prompt exists.
+			var useLegacyWeeklyShape = useWeeklyPrompt || dayOfWeek == DayOfWeek.Monday;
 
-			if (dayOfWeek == DayOfWeek.Monday || useWeeklyPrompt)
+			var systemPrompt = useWeeklyPrompt
+				? StandupPrompts.GetSystemPrompt(DayOfWeek.Monday)
+				: StandupPrompts.GetSystemPrompt(dayOfWeek);
+
+			var todayStr = todayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+			var yesterdayStr = yesterdayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+			string userMessage;
+			if (useLegacyWeeklyShape)
 			{
+				// Monday/weekly reflect back on the previous week, so include its items too
 				var prevWeek = DateOnly.Parse(weekOf, CultureInfo.InvariantCulture)
 					.AddDays(-7)
 					.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
@@ -169,51 +181,59 @@ internal static class StandupEndpoints
 					.ToListAsync();
 
 				items = [.. prevItems, .. items];
+				var workItemsJson = JsonSerializer.Serialize(items, JsonOptions);
+				userMessage = StandupPrompts.BuildWeeklyUserMessage(workItemsJson, todayStr, yesterdayStr);
 			}
-
-			var workItemsJson = JsonSerializer.Serialize(items, JsonOptions);
-			var systemPrompt = useWeeklyPrompt
-				? StandupPrompts.GetSystemPrompt(DayOfWeek.Monday)
-				: StandupPrompts.GetSystemPrompt(dayOfWeek);
-
-			// On Fridays, fetch consumed learning queue items for the week
-			string? learningQueueJson = null;
-			if (dayOfWeek == DayOfWeek.Friday && !useWeeklyPrompt)
+			else
 			{
-				var weekStart = DateOnly.Parse(weekOf, CultureInfo.InvariantCulture);
-				var consumedItems = await db.ReadWatchItems
-					.AsNoTracking()
-					.Where(r => r.IsDone && r.WeekConsumed == weekStart
-						&& (r.Type == Enums.ReadWatchType.Experiment || r.WorthSharing == true))
-					.OrderByDescending(r => r.Type == Enums.ReadWatchType.Experiment)
-					.ThenByDescending(r => r.WorthSharing)
-					.ToListAsync();
+				var logger = loggerFactory.CreateLogger(nameof(StandupEndpoints));
 
-				if (consumedItems.Count > 0)
-					learningQueueJson = JsonSerializer.Serialize(consumedItems, JsonOptions);
-			}
-
-			// Include today's calendar forecast (persisted by the planning modal) for daily standups
-			string? forecastJson = null;
-			if (!useWeeklyPrompt)
-			{
-				forecastJson = await db.WorkSessions
+				// Today's calendar forecast (persisted by the planning modal), trimmed to the
+				// two fields the prompt uses
+				var forecastJson = await db.WorkSessions
 					.AsNoTracking()
 					.Where(s => s.Date == todayDate)
 					.Select(s => s.CalendarForecastJson)
 					.FirstOrDefaultAsync();
+				var forecast = StandupContextBuilder.TryParseForecast(forecastJson, logger);
+
+				var context = StandupContextBuilder.Build(items, todayDate, yesterdayDate, forecast);
+				var contextJson = JsonSerializer.Serialize(context, JsonOptions);
+
+				// Exclude the opener used in yesterday's saved standup so it never repeats back-to-back
+				var previousMarkdown = await db.UpdateComms
+					.AsNoTracking()
+					.Where(c => c.CommType == CommType.DailyStandup && c.Date == yesterdayDate)
+					.Select(c => c.Markdown)
+					.FirstOrDefaultAsync();
+				var opener = StandupPrompts.PickOpener(context.Yesterday.OneThing?.Status, previousMarkdown);
+
+				// On Fridays, fetch consumed learning queue items for the week
+				string? learningQueueJson = null;
+				if (dayOfWeek == DayOfWeek.Friday)
+				{
+					var weekStart = DateOnly.Parse(weekOf, CultureInfo.InvariantCulture);
+					var consumedItems = await db.ReadWatchItems
+						.AsNoTracking()
+						.Where(r => r.IsDone && r.WeekConsumed == weekStart
+							&& (r.Type == Enums.ReadWatchType.Experiment || r.WorthSharing == true))
+						.OrderByDescending(r => r.Type == Enums.ReadWatchType.Experiment)
+						.ThenByDescending(r => r.WorthSharing)
+						.ToListAsync();
+
+					if (consumedItems.Count > 0)
+						learningQueueJson = JsonSerializer.Serialize(consumedItems, JsonOptions);
+				}
+
+				userMessage = StandupPrompts.BuildUserMessage(todayStr, yesterdayStr, contextJson, opener, learningQueueJson);
 			}
 
 			var chatHistory = new ChatHistory();
 			chatHistory.AddSystemMessage(systemPrompt);
-			chatHistory.AddUserMessage(StandupPrompts.BuildUserMessage(
-				workItemsJson,
-				todayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-				yesterdayDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-				learningQueueJson,
-				forecastJson));
+			chatHistory.AddUserMessage(userMessage);
 
-			var response = await chatService.GetChatMessageContentAsync(chatHistory);
+			var settings = new OpenAIPromptExecutionSettings { Temperature = 0.35 };
+			var response = await chatService.GetChatMessageContentAsync(chatHistory, settings);
 
 			return Results.Ok(new { markdown = response.Content });
 		});

--- a/api/src/Endpoints/StandupEndpoints.cs
+++ b/api/src/Endpoints/StandupEndpoints.cs
@@ -20,6 +20,15 @@ internal static class StandupEndpoints
 		Converters = { new JsonStringEnumConverter() },
 	};
 
+	// The standup context is serialized without null members so a small model never sees a
+	// literal "null" (e.g. an absent weeklyGoal or oneThing) that it would otherwise echo verbatim.
+	private static readonly JsonSerializerOptions ContextJsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		Converters = { new JsonStringEnumConverter() },
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	};
+
 	public static RouteGroupBuilder MapStandupEndpoints(this WebApplication app)
 	{
 		var group = app.MapGroup("/api/standup");
@@ -198,7 +207,7 @@ internal static class StandupEndpoints
 				var forecast = StandupContextBuilder.TryParseForecast(forecastJson, logger);
 
 				var context = StandupContextBuilder.Build(items, todayDate, yesterdayDate, forecast);
-				var contextJson = JsonSerializer.Serialize(context, JsonOptions);
+				var contextJson = JsonSerializer.Serialize(context, ContextJsonOptions);
 
 				// Exclude the opener used in yesterday's saved standup so it never repeats back-to-back
 				var previousMarkdown = await db.UpdateComms
@@ -225,7 +234,7 @@ internal static class StandupEndpoints
 						learningQueueJson = JsonSerializer.Serialize(consumedItems, JsonOptions);
 				}
 
-				userMessage = StandupPrompts.BuildUserMessage(todayStr, yesterdayStr, contextJson, opener, learningQueueJson);
+				userMessage = StandupPrompts.BuildUserMessage(todayStr, yesterdayStr, contextJson, opener, context.WeeklyGoal, learningQueueJson);
 			}
 
 			var chatHistory = new ChatHistory();

--- a/api/src/Prompts/StandupContextBuilder.cs
+++ b/api/src/Prompts/StandupContextBuilder.cs
@@ -1,0 +1,99 @@
+using System.Text.Json;
+using DailyWork.Api.Dtos;
+using DailyWork.Api.Entities;
+using DailyWork.Api.Enums;
+
+namespace DailyWork.Api.Prompts;
+
+internal static partial class StandupContextBuilder
+{
+	[LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse calendar forecast JSON for standup; omitting forecast")]
+	private static partial void LogForecastParseFailure(ILogger logger, Exception exception);
+
+	private static readonly JsonSerializerOptions ForecastJsonOptions = new()
+	{
+		PropertyNameCaseInsensitive = true,
+	};
+
+	internal static StandupContext Build(
+		IReadOnlyList<WorkItem> items,
+		DateOnly today,
+		DateOnly yesterday,
+		StandupForecast? forecast)
+	{
+		var smallThings = items
+			.Where(w => w.Category == WorkItemCategory.SmallThing)
+			.OrderBy(w => w.SortOrder)
+			.ThenBy(w => w.CreatedAt)
+			.ToList();
+
+		var weeklyGoal = items
+			.Where(w => w.Category == WorkItemCategory.BigThing)
+			.OrderBy(w => w.SortOrder)
+			.ThenBy(w => w.CreatedAt)
+			.Select(w => w.Title)
+			.FirstOrDefault();
+
+		var yesterdayItems = smallThings.Where(w => w.Date == yesterday).ToList();
+		// Items that sat on (or before) yesterday but were moved forward — their Date no
+		// longer matches, so they'd otherwise vanish from the standup entirely.
+		var carriedAway = smallThings
+			.Where(w => w.TimesMoved > 0 && w.OriginalDate <= yesterday && w.Date > yesterday)
+			.ToList();
+
+		var oneThingSource = yesterdayItems.FirstOrDefault();
+		var yesterdayOneThing = oneThingSource is not null
+			? new StandupItem(oneThingSource.Title, StatusOf(oneThingSource))
+			: null;
+		if (oneThingSource is null)
+		{
+			oneThingSource = carriedAway.FirstOrDefault();
+			if (oneThingSource is not null)
+				yesterdayOneThing = new StandupItem(oneThingSource.Title, "carried");
+		}
+
+		var yesterdayOthers = yesterdayItems
+			.Where(w => w != oneThingSource)
+			.Select(w => new StandupItem(w.Title, StatusOf(w)))
+			.Concat(carriedAway
+				.Where(w => w != oneThingSource)
+				.Select(w => new StandupItem(w.Title, "carried")))
+			.ToList();
+
+		var todayItems = smallThings.Where(w => w.Date == today && !w.IsSkipped).ToList();
+		var todayOneThing = todayItems.Count > 0
+			? new StandupItem(todayItems[0].Title, StatusOf(todayItems[0]))
+			: null;
+		var alsoOnDeck = todayItems.Skip(1).Select(w => w.Title).ToList();
+
+		return new StandupContext(
+			weeklyGoal,
+			new StandupYesterday(yesterdayOneThing, yesterdayOthers),
+			new StandupToday(todayOneThing, alsoOnDeck),
+			forecast?.SyncMeetings ?? [],
+			forecast?.UpcomingPto ?? []);
+	}
+
+	internal static StandupForecast? TryParseForecast(string? json, ILogger logger)
+	{
+		if (string.IsNullOrWhiteSpace(json))
+			return null;
+
+		try
+		{
+			return JsonSerializer.Deserialize<StandupForecast>(json, ForecastJsonOptions);
+		}
+		catch (JsonException ex)
+		{
+			LogForecastParseFailure(logger, ex);
+			return null;
+		}
+	}
+
+	private static string StatusOf(WorkItem item) => item switch
+	{
+		{ IsDone: true } => "done",
+		{ IsSkipped: true } => "skipped",
+		_ => "notDone",
+	};
+}

--- a/api/src/Prompts/StandupPrompts.cs
+++ b/api/src/Prompts/StandupPrompts.cs
@@ -56,11 +56,17 @@ internal static class StandupPrompts
 		string yesterday,
 		string standupContextJson,
 		string? opener,
+		string? weeklyGoal,
 		string? learningQueueJson = null)
 	{
 		var message = $"Today's date: {today}\nYesterday's date: {yesterday}\n\nStandup context:\n{standupContextJson}";
 		if (opener is not null)
 			message += $"\n\nOpen the first answer with exactly: \"{opener}\"";
+		// Inject the weekly-goal decision as an explicit directive rather than trusting the model to
+		// read it off the JSON — a small model otherwise fills the goal slot with the literal "null".
+		message += weeklyGoal is not null
+			? $"\n\nFor question 2, tie today's One Thing to this exact weekly goal: \"{weeklyGoal}\"."
+			: "\n\nThere is no weekly goal this week — for question 2, state only today's One Thing and do not mention a weekly goal at all.";
 		if (learningQueueJson is not null)
 			message += $"\n\nLearning queue items consumed this week:\n{learningQueueJson}";
 		return message;
@@ -72,7 +78,7 @@ internal static class StandupPrompts
 	private static string GetMidWeekPrompt() => string.Join("\n\n",
 		Intro(3),
 		ContextFieldsBlock,
-		OutputStructureLine,
+		OutputRules(3),
 		QuestionOneBlock,
 		QuestionTwoBlock,
 		PtoQuestionBlock,
@@ -82,7 +88,7 @@ internal static class StandupPrompts
 		Intro(4),
 		ContextFieldsBlock,
 		LearningQueueFieldsBlock,
-		OutputStructureLine,
+		OutputRules(4),
 		QuestionOneBlock,
 		QuestionTwoBlock,
 		PtoQuestionBlock,
@@ -107,8 +113,12 @@ internal static class StandupPrompts
         Status meanings: "done" = completed, "skipped" = intentionally skipped, "carried" = not finished and moved to a later day, "notDone" = not completed.
         """;
 
-	private const string OutputStructureLine =
-		"Output exactly this structure (use ### for each question heading):";
+	private static string OutputRules(int questionCount) => $"""
+        Output format — these rules are absolute and apply to EVERY question:
+        - Emit all {questionCount} headings below exactly as written, each on its own line starting with "### ", in order. Output all {questionCount} even when an answer is short, negative, or "No".
+        - Write each answer on the line(s) directly beneath its own heading. Never merge answers together, never drop a heading, never leave a heading with no answer under it.
+        - Never print raw field values such as "notDone", "carried", "skipped", or "null" — always express them in natural first-person language.
+        """;
 
 	private const string QuestionOneBlock = """
         ### Did you complete your One Thing yesterday?
@@ -116,18 +126,18 @@ internal static class StandupPrompts
 
         Smaller stuff: knocked out **<done item title>**, carried **<carried item title>**.
 
-        The first line addresses ONLY yesterday.oneThing. Open with exactly the opener line provided in the user message, verbatim, then finish the sentence to match yesterday.oneThing's status. If yesterday.oneThing is null (no opener provided), open with one short neutral line saying nothing was tracked yesterday.
-        Then a BLANK LINE, then a "Smaller stuff:" line summarizing yesterday.others — describe "carried" items as carried. Omit the "Smaller stuff:" line entirely when yesterday.others is empty.
+        The answer under this heading addresses ONLY yesterday.oneThing. Begin with exactly the opener line provided in the user message, verbatim, then one short clause reflecting its status (done / still in progress / not done). If yesterday.oneThing is null, the entire answer under this heading is exactly: Nothing tracked yesterday. (Still keep the heading above it.)
+        Then, only when yesterday.others is non-empty, a BLANK LINE and a "Smaller stuff:" line summarizing them — describe "carried" items as carried. Omit the "Smaller stuff:" line entirely when yesterday.others is empty.
         """;
 
 	private const string QuestionTwoBlock = """
         ### What's the One Thing you will complete today in service of the weekly goal?
-        **<today one thing title>**, feeding the weekly goal of **<weeklyGoal>**.
+        **<today one thing title>**, in service of the weekly goal of **<weeklyGoal>**.
 
         Also on deck: <alsoOnDeck titles>, plus syncs: <syncMeetings>.
 
-        The first line is ONLY today.oneThing tied back to the weekly goal — use the exact weeklyGoal value from the context, never a goal from an example. If weeklyGoal is null, omit the weekly-goal clause entirely; do not invent one.
-        Then a BLANK LINE, then "Also on deck:" listing today.alsoOnDeck.
+        The first line states today.oneThing. If the context has a weeklyGoal value, tie it in using that exact value (never a goal from an example). If weeklyGoal is absent, state ONLY today.oneThing and stop the sentence there — do not write the words "weekly goal", and never write "null".
+        Then a BLANK LINE, then "Also on deck:" listing today.alsoOnDeck (say "nothing else" when it is empty).
         If syncMeetings is non-empty, fold them into the "Also on deck:" line as syncs (e.g. ", plus syncs: Ali / Jared"). Do not repeat a sync that already appears as a task, and do not invent syncs when syncMeetings is empty.
         """;
 

--- a/api/src/Prompts/StandupPrompts.cs
+++ b/api/src/Prompts/StandupPrompts.cs
@@ -2,6 +2,23 @@ namespace DailyWork.Api.Prompts;
 
 internal static class StandupPrompts
 {
+	internal static readonly string[] DoneOpeners =
+	[
+		"Hell yea!", "YESSIR!", "You know it!", "YES!", "Crushed it.",
+		"Nailed it.", "Lock it in.", "Big day yesterday.", "Clean sweep.", "All green, baby.",
+	];
+
+	internal static readonly string[] NotDoneOpeners =
+	[
+		"NOPE.", "That's funny.", "Not even close.", "What was I thinking?", "Lol no.",
+		"About that...", "Let's not talk about it.", "Swing and a miss.", "Bold of you to ask.", "Yeah... no.",
+	];
+
+	internal static readonly string[] PartialOpeners =
+	[
+		"Kinda.", "Sort of.", "Getting there.", "Halfway hero.", "Progress, not perfection.",
+	];
+
 	internal static string GetSystemPrompt(DayOfWeek day) => day switch
 	{
 		DayOfWeek.Monday => GetMondayPrompt(),
@@ -9,123 +26,130 @@ internal static class StandupPrompts
 		_ => GetMidWeekPrompt(),
 	};
 
-	internal static string BuildUserMessage(string workItemsJson, string today, string yesterday, string? learningQueueJson = null, string? forecastJson = null)
+	internal static string? PickOpener(string? yesterdayStatus, string? previousStandupMarkdown)
 	{
-		var message = $"Today's date: {today}\nYesterday's date: {yesterday}\n\nWork items:\n{workItemsJson}";
+		var bucket = yesterdayStatus switch
+		{
+			"done" => DoneOpeners,
+			"carried" => PartialOpeners,
+			"skipped" or "notDone" => NotDoneOpeners,
+			_ => null,
+		};
+		if (bucket is null)
+			return null;
+
+		var candidates = bucket;
+		if (previousStandupMarkdown is not null)
+		{
+			var unused = bucket
+				.Where(o => !previousStandupMarkdown.Contains(o, StringComparison.Ordinal))
+				.ToArray();
+			if (unused.Length > 0)
+				candidates = unused;
+		}
+
+		return candidates[Random.Shared.Next(candidates.Length)];
+	}
+
+	internal static string BuildUserMessage(
+		string today,
+		string yesterday,
+		string standupContextJson,
+		string? opener,
+		string? learningQueueJson = null)
+	{
+		var message = $"Today's date: {today}\nYesterday's date: {yesterday}\n\nStandup context:\n{standupContextJson}";
+		if (opener is not null)
+			message += $"\n\nOpen the first answer with exactly: \"{opener}\"";
 		if (learningQueueJson is not null)
 			message += $"\n\nLearning queue items consumed this week:\n{learningQueueJson}";
-		if (forecastJson is not null)
-			message += $"\n\nDaily calendar forecast:\n{forecastJson}";
 		return message;
 	}
 
-	private static string GetMidWeekPrompt() => """
-        You are a standup response writer. Answer exactly 3 standup questions using the provided work items.
-        Do NOT add summaries, tables, counts, or extra sections beyond the 3 answers.
+	internal static string BuildWeeklyUserMessage(string workItemsJson, string today, string yesterday) =>
+		$"Today's date: {today}\nYesterday's date: {yesterday}\n\nWork items:\n{workItemsJson}";
 
-        Work item fields:
-        - category: "BigThing" = weekly goal, "SmallThing" = daily task
-        - isDone: completion status
-        - date: scheduled day
-        - sortOrder: items are pre-sorted; the FIRST SmallThing for a given date is the "One Thing" / "big thing of the day"
+	private static string GetMidWeekPrompt() => string.Join("\n\n",
+		Intro(3),
+		ContextFieldsBlock,
+		OutputStructureLine,
+		QuestionOneBlock,
+		QuestionTwoBlock,
+		PtoQuestionBlock,
+		StyleRules(140));
 
-        Daily calendar forecast (a JSON block may be provided at the end of the user message; it may be absent):
-        - syncMeetings: names of sync meetings on today's calendar
-        - upcomingPTO: out-of-office events with title, start, end
-        Use ONLY syncMeetings and upcomingPTO from the forecast — ignore every other forecast field.
-
-        Output exactly this structure (use ### for each question heading):
-
-        ### Did you complete your One Thing yesterday?
-        Kinda — got **Examine PDL payload** across the line.
-
-        Smaller stuff: knocked out **Weekly Kickoff Prep**, carried **Graham CRM+ discussion** and **Submit AI Qualifying Race**.
-
-        The first line addresses ONLY yesterday's big thing of the day — the first SmallThing (by sortOrder) whose `date` EXACTLY matches the "Yesterday's date" line provided in the user message. Do NOT infer yesterday from today's date; use the value given. Lead with an opener that varies based on whether THAT specific item was done:
-        - DONE: enthusiastic — pick one: "Hell yea!", "YESSIR!", "You know it!", "YES!", "Crushed it.", "Nailed it.", "Lock it in.", "Big day yesterday.", "Clean sweep.", "All green, baby."
-        - NOT DONE: self-deprecating — pick one: "NOPE.", "That's funny.", "Not even close.", "What was I thinking?", "Lol no.", "About that...", "Let's not talk about it.", "Swing and a miss.", "Bold of you to ask.", "Yeah... no."
-        - PARTIAL CREDIT (e.g. in progress): hedging — pick one: "Kinda.", "Sort of.", "Getting there.", "Halfway hero.", "Progress, not perfection."
-        Pick a different one each time — never repeat the same opener twice in a row.
-
-        Then a BLANK LINE, then a "Smaller stuff:" line summarizing the other SmallThings whose `date` matches the provided yesterday's date (done/carried).
-
-        ### What's the One Thing you will complete today in service of the weekly goal?
-        **Start Insights work — examine PDL payload/data store**, feeding the weekly goal of **Data Products support**.
-
-        Also on deck: Submit AI Qualifying Race, Align on CRM+ OKRs, Sync with Ali.
-
-        The first line is ONLY today's big thing of the day (first SmallThing by sortOrder for today) tied back to the weekly BigThing.
-        Then a BLANK LINE, then "Also on deck:" listing today's remaining SmallThings.
-        If the forecast lists syncMeetings, fold them into the "Also on deck:" line as syncs (e.g. ", plus syncs: Ali / Jared"). Do not repeat a sync that already appears as a task, and do not invent syncs when the forecast is absent.
-
-        ### Do you have any upcoming PTO or unavailability the team should know about?
-        OOO Jul 24 – Jul 30 (Family Time).
-
-        If the forecast's upcomingPTO has entries, answer from it: one fragment per entry formatted "OOO {Mon D} – {Mon D}" from the start/end dates, with the title (leading emoji stripped) in parentheses when it adds context; join multiple entries with "; ". If the forecast is absent or upcomingPTO is empty, answer exactly "No".
-
-        Style rules:
-        - Write in first person. This gets pasted into Geekbot.
-        - Bold task names and the weekly goal with **markdown bold**.
-        - Keep answers short — lead with the key item, not a full sentence. Fragments are fine.
-        - Do NOT repeat the questions word-for-word if you can keep it clear without them.
-        - Under 140 words total.
-        """;
+	private static string GetFridayPrompt() => string.Join("\n\n",
+		Intro(4),
+		ContextFieldsBlock,
+		LearningQueueFieldsBlock,
+		OutputStructureLine,
+		QuestionOneBlock,
+		QuestionTwoBlock,
+		PtoQuestionBlock,
+		QuestionFourBlock,
+		StyleRules(180));
 
 	private static string GetMondayPrompt() => "Monday prompt — TODO";
 
-	private static string GetFridayPrompt() => """
-        You are a standup response writer. Answer exactly 4 standup questions using the provided work items and learning queue data.
-        Do NOT add summaries, tables, counts, or extra sections beyond the 4 answers.
+	private static string Intro(int questionCount) =>
+		$"You are a standup response writer. Answer exactly {questionCount} standup questions using the provided standup context.\n" +
+		$"Do NOT add summaries, tables, counts, or extra sections beyond the {questionCount} answers.";
 
-        Work item fields:
-        - category: "BigThing" = weekly goal, "SmallThing" = daily task
-        - isDone: completion status
-        - date: scheduled day
-        - sortOrder: items are pre-sorted; the FIRST SmallThing for a given date is the "One Thing" / "big thing of the day"
-
-        Daily calendar forecast (a JSON block may be provided at the end of the user message; it may be absent):
+	private const string ContextFieldsBlock = """
+        The user message contains a "Standup context" JSON payload. Every value in it is precomputed — do NOT re-derive dates, ordering, or statuses:
+        - weeklyGoal: the weekly goal (BigThing) title; may be null
+        - yesterday.oneThing: yesterday's "One Thing" (the big thing of the day) with its status; may be null
+        - yesterday.others: yesterday's remaining tasks, each with a status
+        - today.oneThing: today's "One Thing"
+        - today.alsoOnDeck: today's remaining task titles
         - syncMeetings: names of sync meetings on today's calendar
         - upcomingPTO: out-of-office events with title, start, end
-        Use ONLY syncMeetings and upcomingPTO from the forecast — ignore every other forecast field.
+        Status meanings: "done" = completed, "skipped" = intentionally skipped, "carried" = not finished and moved to a later day, "notDone" = not completed.
+        """;
 
+	private const string OutputStructureLine =
+		"Output exactly this structure (use ### for each question heading):";
+
+	private const string QuestionOneBlock = """
+        ### Did you complete your One Thing yesterday?
+        <opener> — got **<yesterday one thing title>** across the line.
+
+        Smaller stuff: knocked out **<done item title>**, carried **<carried item title>**.
+
+        The first line addresses ONLY yesterday.oneThing. Open with exactly the opener line provided in the user message, verbatim, then finish the sentence to match yesterday.oneThing's status. If yesterday.oneThing is null (no opener provided), open with one short neutral line saying nothing was tracked yesterday.
+        Then a BLANK LINE, then a "Smaller stuff:" line summarizing yesterday.others — describe "carried" items as carried. Omit the "Smaller stuff:" line entirely when yesterday.others is empty.
+        """;
+
+	private const string QuestionTwoBlock = """
+        ### What's the One Thing you will complete today in service of the weekly goal?
+        **<today one thing title>**, feeding the weekly goal of **<weeklyGoal>**.
+
+        Also on deck: <alsoOnDeck titles>, plus syncs: <syncMeetings>.
+
+        The first line is ONLY today.oneThing tied back to the weekly goal — use the exact weeklyGoal value from the context, never a goal from an example. If weeklyGoal is null, omit the weekly-goal clause entirely; do not invent one.
+        Then a BLANK LINE, then "Also on deck:" listing today.alsoOnDeck.
+        If syncMeetings is non-empty, fold them into the "Also on deck:" line as syncs (e.g. ", plus syncs: Ali / Jared"). Do not repeat a sync that already appears as a task, and do not invent syncs when syncMeetings is empty.
+        """;
+
+	private const string PtoQuestionBlock = """
+        ### Do you have any upcoming PTO or unavailability the team should know about?
+        OOO Jul 24 – Jul 30 (Family Time).
+
+        If upcomingPTO has entries, answer from it: one fragment per entry formatted "OOO {Mon D} – {Mon D}" from the start/end dates, with the title (leading emoji stripped) in parentheses when it adds context; join multiple entries with "; ". If upcomingPTO is empty, answer exactly "No".
+        """;
+
+	private const string LearningQueueFieldsBlock = """
         Learning queue item fields (provided separately, may be empty):
         - title: name of the resource
         - url: link to the resource
         - type: "Experiment" = hands-on experiment, "Read"/"Watch"/"Learn" = consumed content
         - worthSharing: true if marked as worth sharing to the team
         - notes: the user's findings/takeaways
+        """;
 
-        Output exactly this structure (use ### for each question heading):
-
-        ### Did you complete your One Thing yesterday?
-        Kinda — got **Examine PDL payload** across the line.
-
-        Smaller stuff: knocked out **Weekly Kickoff Prep**, carried **Graham CRM+ discussion** and **Submit AI Qualifying Race**.
-
-        The first line addresses ONLY yesterday's big thing of the day — the first SmallThing (by sortOrder) whose `date` EXACTLY matches the "Yesterday's date" line provided in the user message. Do NOT infer yesterday from today's date; use the value given. Lead with an opener that varies based on whether THAT specific item was done:
-        - DONE: enthusiastic — pick one: "Hell yea!", "YESSIR!", "You know it!", "YES!", "Crushed it.", "Nailed it.", "Lock it in.", "Big day yesterday.", "Clean sweep.", "All green, baby."
-        - NOT DONE: self-deprecating — pick one: "NOPE.", "That's funny.", "Not even close.", "What was I thinking?", "Lol no.", "About that...", "Let's not talk about it.", "Swing and a miss.", "Bold of you to ask.", "Yeah... no."
-        - PARTIAL CREDIT (e.g. in progress): hedging — pick one: "Kinda.", "Sort of.", "Getting there.", "Halfway hero.", "Progress, not perfection."
-        Pick a different one each time — never repeat the same opener twice in a row.
-
-        Then a BLANK LINE, then a "Smaller stuff:" line summarizing the other SmallThings whose `date` matches the provided yesterday's date (done/carried).
-
-        ### What's the One Thing you will complete today in service of the weekly goal?
-        **Start Insights work — examine PDL payload/data store**, feeding the weekly goal of **Data Products support**.
-
-        Also on deck: Submit AI Qualifying Race, Align on CRM+ OKRs, Sync with Ali.
-
-        The first line is ONLY today's big thing of the day (first SmallThing by sortOrder for today) tied back to the weekly BigThing.
-        Then a BLANK LINE, then "Also on deck:" listing today's remaining SmallThings.
-        If the forecast lists syncMeetings, fold them into the "Also on deck:" line as syncs (e.g. ", plus syncs: Ali / Jared"). Do not repeat a sync that already appears as a task, and do not invent syncs when the forecast is absent.
-
-        ### Do you have any upcoming PTO or unavailability the team should know about?
-        OOO Jul 24 – Jul 30 (Family Time).
-
-        If the forecast's upcomingPTO has entries, answer from it: one fragment per entry formatted "OOO {Mon D} – {Mon D}" from the start/end dates, with the title (leading emoji stripped) in parentheses when it adds context; join multiple entries with "; ". If the forecast is absent or upcomingPTO is empty, answer exactly "No".
-
+	private const string QuestionFourBlock = """
         ### What's one experiment, improvement, or lesson from this week that helped you (or could help the team)?
-        This week I tried **[title]** — [revised notes as a concise value prop]. Worth checking out: [url]
+        This week I tried **<title>** — <revised notes as a concise value prop>. Worth checking out: <url>
 
         Bonus points for a Loom video showing it!
 
@@ -139,12 +163,14 @@ internal static class StandupPrompts
         - Revise the user's notes for clarity — tighten the language, highlight the value prop, make it useful for teammates who haven't seen the resource.
         - Include the URL as a link if available.
         - Keep it to 2-3 sentences max.
+        """;
 
+	private static string StyleRules(int maxWords) => $"""
         Style rules:
         - Write in first person. This gets pasted into Geekbot.
         - Bold task names and the weekly goal with **markdown bold**.
         - Keep answers short — lead with the key item, not a full sentence. Fragments are fine.
         - Do NOT repeat the questions word-for-word if you can keep it clear without them.
-        - Under 180 words total.
+        - Under {maxWords} words total.
         """;
 }

--- a/api/tests/Fixtures/FakeChatCompletionService.cs
+++ b/api/tests/Fixtures/FakeChatCompletionService.cs
@@ -7,6 +7,7 @@ public class FakeChatCompletionService : IChatCompletionService
 {
 	public string ResponseContent { get; set; } = "**Mock standup response**";
 	public ChatHistory? LastChatHistory { get; private set; }
+	public PromptExecutionSettings? LastExecutionSettings { get; private set; }
 
 	public IReadOnlyDictionary<string, object?> Attributes { get; } = new Dictionary<string, object?>();
 
@@ -17,6 +18,7 @@ public class FakeChatCompletionService : IChatCompletionService
 		CancellationToken cancellationToken = default)
 	{
 		LastChatHistory = chatHistory;
+		LastExecutionSettings = executionSettings;
 		IReadOnlyList<ChatMessageContent> result = [new ChatMessageContent(AuthorRole.Assistant, ResponseContent)];
 		return Task.FromResult(result);
 	}

--- a/api/tests/StandupContextBuilderTests.cs
+++ b/api/tests/StandupContextBuilderTests.cs
@@ -1,0 +1,239 @@
+using DailyWork.Api.Dtos;
+using DailyWork.Api.Entities;
+using DailyWork.Api.Enums;
+using DailyWork.Api.Prompts;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace DailyWork.Api.Tests;
+
+public class StandupContextBuilderTests
+{
+	private static readonly DateOnly Today = new(2026, 4, 8);
+	private static readonly DateOnly Yesterday = new(2026, 4, 7);
+
+	private static WorkItem CreateItem(
+		string title,
+		DateOnly date,
+		WorkItemCategory category = WorkItemCategory.SmallThing,
+		bool isDone = false,
+		bool isSkipped = false,
+		int sortOrder = 1,
+		int timesMoved = 0,
+		DateOnly? originalDate = null) => new()
+		{
+			Title = title,
+			Category = category,
+			IsDone = isDone,
+			IsSkipped = isSkipped,
+			SortOrder = sortOrder,
+			Date = date,
+			WeekOf = "2026-04-06",
+			TimesMoved = timesMoved,
+			OriginalDate = originalDate ?? date,
+		};
+
+	[Fact]
+	public void Build_SetsWeeklyGoal_WhenBigThingExists()
+	{
+		var items = new[]
+		{
+			CreateItem("Ship insights pipeline", Yesterday, WorkItemCategory.BigThing),
+			CreateItem("Small task", Today),
+		};
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.WeeklyGoal.ShouldBe("Ship insights pipeline");
+	}
+
+	[Fact]
+	public void Build_NullWeeklyGoal_WhenNoBigThing()
+	{
+		var items = new[] { CreateItem("Small task", Today) };
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.WeeklyGoal.ShouldBeNull();
+	}
+
+	[Fact]
+	public void Build_PicksFirstSmallThingBySortOrder_WhenMultipleYesterdayItems()
+	{
+		var items = new[]
+		{
+			CreateItem("Second task", Yesterday, sortOrder: 2),
+			CreateItem("One thing", Yesterday, sortOrder: 1, isDone: true),
+			CreateItem("Third task", Yesterday, sortOrder: 3),
+		};
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing!.Title.ShouldBe("One thing");
+		context.Yesterday.Others.Select(o => o.Title).ShouldBe(["Second task", "Third task"]);
+	}
+
+	[Fact]
+	public void Build_StatusDone_WhenIsDone()
+	{
+		var items = new[] { CreateItem("Finished task", Yesterday, isDone: true) };
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing!.Status.ShouldBe("done");
+	}
+
+	[Fact]
+	public void Build_StatusSkipped_WhenIsSkipped()
+	{
+		var items = new[] { CreateItem("Skipped task", Yesterday, isSkipped: true) };
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing!.Status.ShouldBe("skipped");
+	}
+
+	[Fact]
+	public void Build_StatusNotDone_WhenNeitherDoneNorSkipped()
+	{
+		var items = new[] { CreateItem("Open task", Yesterday) };
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing!.Status.ShouldBe("notDone");
+	}
+
+	[Fact]
+	public void Build_OneThingCarried_WhenYesterdayItemMovedForward()
+	{
+		// The only yesterday item was moved to today — its Date no longer matches yesterday
+		var items = new[]
+		{
+			CreateItem("Carried task", Today, timesMoved: 1, originalDate: Yesterday),
+			CreateItem("Fresh today task", Today, sortOrder: 2),
+		};
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing!.Title.ShouldBe("Carried task");
+		context.Yesterday.OneThing.Status.ShouldBe("carried");
+		context.Today.OneThing!.Title.ShouldBe("Carried task");
+	}
+
+	[Fact]
+	public void Build_IncludesCarriedItemInOthers_WhenYesterdayHadItsOwnOneThing()
+	{
+		var items = new[]
+		{
+			CreateItem("Yesterday one thing", Yesterday, sortOrder: 1, isDone: true),
+			CreateItem("Moved task", Today, sortOrder: 2, timesMoved: 1, originalDate: Yesterday),
+		};
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing!.Title.ShouldBe("Yesterday one thing");
+		context.Yesterday.Others.ShouldContain(o => o.Title == "Moved task" && o.Status == "carried");
+	}
+
+	[Fact]
+	public void Build_YesterdayOneThingNull_WhenNoYesterdayItems()
+	{
+		var items = new[] { CreateItem("Today only", Today) };
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Yesterday.OneThing.ShouldBeNull();
+		context.Yesterday.Others.ShouldBeEmpty();
+	}
+
+	[Fact]
+	public void Build_PopulatesTodayOneThingAndAlsoOnDeck_WhenTodayItemsExist()
+	{
+		var items = new[]
+		{
+			CreateItem("Today one thing", Today, sortOrder: 1),
+			CreateItem("Deck item A", Today, sortOrder: 2),
+			CreateItem("Deck item B", Today, sortOrder: 3),
+		};
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Today.OneThing!.Title.ShouldBe("Today one thing");
+		context.Today.AlsoOnDeck.ShouldBe(["Deck item A", "Deck item B"]);
+	}
+
+	[Fact]
+	public void Build_ExcludesSkippedFromToday_WhenTodayItemSkipped()
+	{
+		var items = new[]
+		{
+			CreateItem("Skipped today", Today, sortOrder: 1, isSkipped: true),
+			CreateItem("Active today", Today, sortOrder: 2),
+		};
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.Today.OneThing!.Title.ShouldBe("Active today");
+		context.Today.AlsoOnDeck.ShouldBeEmpty();
+	}
+
+	[Fact]
+	public void Build_NormalizesForecastToEmptyLists_WhenForecastNull()
+	{
+		var items = new[] { CreateItem("Task", Today) };
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, null);
+
+		context.SyncMeetings.ShouldBeEmpty();
+		context.UpcomingPto.ShouldBeEmpty();
+	}
+
+	[Fact]
+	public void Build_PassesThroughForecastLists_WhenForecastProvided()
+	{
+		var items = new[] { CreateItem("Task", Today) };
+		var forecast = new StandupForecast(
+			["Ali / Jared"],
+			[new StandupPto("Family Time", "2026-07-24", "2026-07-30")]);
+
+		var context = StandupContextBuilder.Build(items, Today, Yesterday, forecast);
+
+		context.SyncMeetings.ShouldBe(["Ali / Jared"]);
+		context.UpcomingPto.ShouldHaveSingleItem().Title.ShouldBe("Family Time");
+	}
+
+	[Fact]
+	public void TryParseForecast_ReturnsNull_WhenMalformedJson()
+	{
+		var forecast = StandupContextBuilder.TryParseForecast("not json{{", NullLogger.Instance);
+
+		forecast.ShouldBeNull();
+	}
+
+	[Fact]
+	public void TryParseForecast_ReturnsNull_WhenNullOrWhitespace()
+	{
+		StandupContextBuilder.TryParseForecast(null, NullLogger.Instance).ShouldBeNull();
+		StandupContextBuilder.TryParseForecast("   ", NullLogger.Instance).ShouldBeNull();
+	}
+
+	[Fact]
+	public void TryParseForecast_ToleratesMissingAndExtraFields_WhenPartialJson()
+	{
+		var json = """
+			{
+				"date": "2026-07-16",
+				"meetings": { "count": 3, "totalHours": 2.5 },
+				"focusTime": { "count": 2, "totalHours": 4 },
+				"upcomingPTO": [{ "title": "🌴 Family Time", "start": "2026-07-24", "end": "2026-07-30", "allDay": true, "eventType": "oof" }]
+			}
+			""";
+
+		var forecast = StandupContextBuilder.TryParseForecast(json, NullLogger.Instance);
+
+		forecast.ShouldNotBeNull();
+		forecast.SyncMeetings.ShouldBeNull();
+		forecast.UpcomingPto.ShouldHaveSingleItem().Title.ShouldBe("🌴 Family Time");
+	}
+}

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -361,7 +361,7 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 	}
 
 	[Fact]
-	public async Task GenerateStandup_SetsWeeklyGoalNull_WhenNoBigThing()
+	public async Task GenerateStandup_OmitsGoalAndInjectsNoGoalDirective_WhenNoBigThing()
 	{
 		// Arrange
 		_factory.ChatCompletionService.ResponseContent = "ok";
@@ -381,7 +381,9 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 		var userMessage = _factory.ChatCompletionService.LastChatHistory!
 			.Last(m => m.Role == AuthorRole.User)
 			.Content!;
-		userMessage.ShouldContain("\"weeklyGoal\":null");
+		// Null members are omitted from the payload so a small model never echoes a literal "null".
+		userMessage.ShouldNotContain("\"weeklyGoal\"");
+		userMessage.ShouldContain("no weekly goal this week");
 	}
 
 	[Fact]

--- a/api/tests/StandupEndpointTests.cs
+++ b/api/tests/StandupEndpointTests.cs
@@ -2,8 +2,10 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DailyWork.Api.Prompts;
 using DailyWork.Api.Tests.Fixtures;
 using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Shouldly;
 using Xunit;
 
@@ -248,7 +250,7 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 	}
 
 	[Fact]
-	public async Task GenerateStandup_IncludesForecastInPrompt_WhenForecastStored()
+	public async Task GenerateStandup_IncludesSyncMeetingsInContext_WhenForecastStored()
 	{
 		// Arrange
 		_factory.ChatCompletionService.ResponseContent = "ok";
@@ -271,12 +273,12 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 		var userMessage = _factory.ChatCompletionService.LastChatHistory!
 			.Last(m => m.Role == AuthorRole.User)
 			.Content!;
-		userMessage.ShouldContain("Daily calendar forecast:");
-		userMessage.ShouldContain("Ali / Jared");
+		userMessage.ShouldContain("Standup context:");
+		userMessage.ShouldContain("\"syncMeetings\":[\"Ali / Jared\"]");
 	}
 
 	[Fact]
-	public async Task GenerateStandup_OmitsForecastSection_WhenNoForecastStored()
+	public async Task GenerateStandup_SendsEmptyForecastArrays_WhenNoForecastStored()
 	{
 		// Arrange
 		_factory.ChatCompletionService.ResponseContent = "ok";
@@ -296,7 +298,8 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 		var userMessage = _factory.ChatCompletionService.LastChatHistory!
 			.Last(m => m.Role == AuthorRole.User)
 			.Content!;
-		userMessage.ShouldNotContain("Daily calendar forecast");
+		userMessage.ShouldContain("\"syncMeetings\":[]");
+		userMessage.ShouldContain("\"upcomingPTO\":[]");
 	}
 
 	[Fact]
@@ -323,7 +326,194 @@ public class StandupEndpointTests : IClassFixture<CustomWebApplicationFactory>, 
 		var userMessage = _factory.ChatCompletionService.LastChatHistory!
 			.Last(m => m.Role == AuthorRole.User)
 			.Content!;
-		userMessage.ShouldNotContain("Daily calendar forecast");
+		userMessage.ShouldNotContain("Ali / Jared");
+		userMessage.ShouldNotContain("Standup context:");
+	}
+
+	[Fact]
+	public async Task GenerateStandup_IncludesWeeklyGoalInContext_WhenBigThingExists()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Insights platform buildout",
+			Category = "BigThing",
+			Date = "2020-01-13",
+		});
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Goal test item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldContain("\"weeklyGoal\":\"Insights platform buildout\"");
+	}
+
+	[Fact]
+	public async Task GenerateStandup_SetsWeeklyGoalNull_WhenNoBigThing()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "No goal item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldContain("\"weeklyGoal\":null");
+	}
+
+	[Fact]
+	public async Task GenerateStandup_InjectsOpener_WhenYesterdayItemExists()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Unfinished yesterday item",
+			Category = "SmallThing",
+			Date = "2020-01-14",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert — item is not done, so the opener comes from the NotDone bucket
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldContain("Open the first answer with exactly:");
+		StandupPrompts.NotDoneOpeners
+			.Any(o => userMessage.Contains($"Open the first answer with exactly: \"{o}\""))
+			.ShouldBeTrue();
+	}
+
+	[Fact]
+	public async Task GenerateStandup_OmitsOpener_WhenNoYesterdayItems()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Today only item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldNotContain("Open the first answer");
+	}
+
+	[Fact]
+	public async Task GenerateStandup_MarksOneThingCarried_WhenYesterdayItemMovedToToday()
+	{
+		// Arrange — create an item dated yesterday, then move it to today
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		var createResponse = await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Carried item",
+			Category = "SmallThing",
+			Date = "2020-01-14",
+		});
+		var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		var id = created.GetProperty("id").GetInt32();
+
+		await _client.PatchAsJsonAsync($"/api/work-items/{id}/move", new { Date = "2020-01-15" });
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert — the moved item is yesterday's One Thing with carried status, opener from Partial bucket
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldContain("""{"title":"Carried item","status":"carried"}""");
+		StandupPrompts.PartialOpeners
+			.Any(o => userMessage.Contains($"Open the first answer with exactly: \"{o}\""))
+			.ShouldBeTrue();
+	}
+
+	[Fact]
+	public async Task GenerateStandup_PassesTemperature_WhenGenerating()
+	{
+		// Arrange
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Temperature test item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var settings = _factory.ChatCompletionService.LastExecutionSettings
+			.ShouldBeOfType<OpenAIPromptExecutionSettings>();
+		settings.Temperature.ShouldBe(0.35);
+	}
+
+	[Fact]
+	public async Task GenerateStandup_SendsEmptyForecastArrays_WhenForecastNotAnObject()
+	{
+		// Arrange — the forecast endpoint only validates that the text is JSON, so a
+		// non-object payload can reach the standup parser
+		_factory.ChatCompletionService.ResponseContent = "ok";
+
+		await _client.PostAsJsonAsync("/api/forecast?date=2020-01-15", new { Json = "[1,2,3]" });
+
+		await _client.PostAsJsonAsync("/api/work-items", new
+		{
+			Title = "Bad forecast item",
+			Category = "SmallThing",
+			Date = "2020-01-15",
+		});
+
+		// Act
+		var response = await _client.PostAsync($"/api/standup/generate?weekOf={TestWeekOf}&today=2020-01-15", null);
+
+		// Assert — generation still succeeds with empty forecast data
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		var userMessage = _factory.ChatCompletionService.LastChatHistory!
+			.Last(m => m.Role == AuthorRole.User)
+			.Content!;
+		userMessage.ShouldContain("\"syncMeetings\":[]");
 	}
 
 	[Fact]

--- a/api/tests/StandupPromptTests.cs
+++ b/api/tests/StandupPromptTests.cs
@@ -64,51 +64,133 @@ public class StandupPromptTests
 	[Fact]
 	public void BuildUserMessage_IncludesTodayAndYesterdayAndJson()
 	{
-		var json = """[{"id":1,"title":"Test"}]""";
+		var contextJson = """{"weeklyGoal":"Test goal"}""";
 
-		var message = StandupPrompts.BuildUserMessage(json, "2026-04-07", "2026-04-06");
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", contextJson, null);
 
 		message.ShouldContain("Today's date: 2026-04-07");
 		message.ShouldContain("Yesterday's date: 2026-04-06");
-		message.ShouldContain(json);
+		message.ShouldContain("Standup context:");
+		message.ShouldContain(contextJson);
 		message.ShouldNotContain("Learning queue");
 	}
 
 	[Fact]
 	public void BuildUserMessage_IncludesLearningQueue_WhenProvided()
 	{
-		var workJson = """[{"id":1,"title":"Test"}]""";
+		var contextJson = """{"weeklyGoal":"Test goal"}""";
 		var learningJson = """[{"title":"Cool experiment","type":"Experiment"}]""";
 
-		var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-10", "2026-04-09", learningJson);
+		var message = StandupPrompts.BuildUserMessage("2026-04-10", "2026-04-09", contextJson, null, learningJson);
 
 		message.ShouldContain("Today's date: 2026-04-10");
 		message.ShouldContain("Yesterday's date: 2026-04-09");
-		message.ShouldContain(workJson);
+		message.ShouldContain(contextJson);
 		message.ShouldContain("Learning queue items consumed this week");
 		message.ShouldContain(learningJson);
 	}
 
 	[Fact]
-	public void BuildUserMessage_AppendsForecastSection_WhenForecastProvided()
+	public void BuildUserMessage_IncludesOpenerLine_WhenOpenerProvided()
 	{
-		var workJson = """[{"id":1,"title":"Test"}]""";
-		var forecastJson = """{"syncMeetings":["Ali / Jared"],"upcomingPTO":[]}""";
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", "Crushed it.");
 
-		var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-07", "2026-04-06", null, forecastJson);
-
-		message.ShouldContain("Daily calendar forecast:");
-		message.ShouldContain(forecastJson);
+		message.ShouldContain("Open the first answer with exactly: \"Crushed it.\"");
 	}
 
 	[Fact]
-	public void BuildUserMessage_OmitsForecastSection_WhenForecastNull()
+	public void BuildUserMessage_OmitsOpenerLine_WhenOpenerNull()
+	{
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", null);
+
+		message.ShouldNotContain("Open the first answer");
+	}
+
+	[Fact]
+	public void BuildWeeklyUserMessage_IncludesDatesAndWorkItems()
 	{
 		var workJson = """[{"id":1,"title":"Test"}]""";
 
-		var message = StandupPrompts.BuildUserMessage(workJson, "2026-04-07", "2026-04-06");
+		var message = StandupPrompts.BuildWeeklyUserMessage(workJson, "2026-04-07", "2026-04-06");
 
-		message.ShouldNotContain("Daily calendar forecast");
+		message.ShouldContain("Today's date: 2026-04-07");
+		message.ShouldContain("Yesterday's date: 2026-04-06");
+		message.ShouldContain("Work items:");
+		message.ShouldContain(workJson);
+	}
+
+	[Fact]
+	public void PickOpener_ReturnsDoneBucketOpener_WhenStatusDone()
+	{
+		var opener = StandupPrompts.PickOpener("done", null);
+
+		StandupPrompts.DoneOpeners.ShouldContain(opener);
+	}
+
+	[Fact]
+	public void PickOpener_ReturnsPartialBucketOpener_WhenStatusCarried()
+	{
+		var opener = StandupPrompts.PickOpener("carried", null);
+
+		StandupPrompts.PartialOpeners.ShouldContain(opener);
+	}
+
+	[Fact]
+	public void PickOpener_ReturnsNotDoneBucketOpener_WhenStatusSkipped()
+	{
+		var opener = StandupPrompts.PickOpener("skipped", null);
+
+		StandupPrompts.NotDoneOpeners.ShouldContain(opener);
+	}
+
+	[Fact]
+	public void PickOpener_ReturnsNull_WhenStatusNull()
+	{
+		var opener = StandupPrompts.PickOpener(null, null);
+
+		opener.ShouldBeNull();
+	}
+
+	[Fact]
+	public void PickOpener_ExcludesPreviousOpener_WhenPresentInMarkdown()
+	{
+		var previousMarkdown = "### Did you complete your One Thing yesterday?\nCrushed it. — got **Thing** done.";
+
+		for (var i = 0; i < 50; i++)
+		{
+			var opener = StandupPrompts.PickOpener("done", previousMarkdown);
+
+			opener.ShouldNotBe("Crushed it.");
+			StandupPrompts.DoneOpeners.ShouldContain(opener);
+		}
+	}
+
+	[Fact]
+	public void PickOpener_FallsBackToFullBucket_WhenAllOpenersInPreviousMarkdown()
+	{
+		var previousMarkdown = string.Join(" ", StandupPrompts.DoneOpeners);
+
+		var opener = StandupPrompts.PickOpener("done", previousMarkdown);
+
+		StandupPrompts.DoneOpeners.ShouldContain(opener);
+	}
+
+	[Fact]
+	public void GetSystemPrompt_OmitsConcreteExampleGoal_WhenMidWeek()
+	{
+		var prompt = StandupPrompts.GetSystemPrompt(DayOfWeek.Tuesday);
+
+		prompt.ShouldNotContain("Data Products support");
+		prompt.ShouldContain("never a goal from an example");
+	}
+
+	[Fact]
+	public void GetSystemPrompt_OmitsConcreteExampleGoal_WhenFriday()
+	{
+		var prompt = StandupPrompts.GetSystemPrompt(DayOfWeek.Friday);
+
+		prompt.ShouldNotContain("Data Products support");
+		prompt.ShouldContain("never a goal from an example");
 	}
 
 	[Fact]

--- a/api/tests/StandupPromptTests.cs
+++ b/api/tests/StandupPromptTests.cs
@@ -66,7 +66,7 @@ public class StandupPromptTests
 	{
 		var contextJson = """{"weeklyGoal":"Test goal"}""";
 
-		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", contextJson, null);
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", contextJson, null, "Test goal");
 
 		message.ShouldContain("Today's date: 2026-04-07");
 		message.ShouldContain("Yesterday's date: 2026-04-06");
@@ -81,7 +81,7 @@ public class StandupPromptTests
 		var contextJson = """{"weeklyGoal":"Test goal"}""";
 		var learningJson = """[{"title":"Cool experiment","type":"Experiment"}]""";
 
-		var message = StandupPrompts.BuildUserMessage("2026-04-10", "2026-04-09", contextJson, null, learningJson);
+		var message = StandupPrompts.BuildUserMessage("2026-04-10", "2026-04-09", contextJson, null, "Test goal", learningJson);
 
 		message.ShouldContain("Today's date: 2026-04-10");
 		message.ShouldContain("Yesterday's date: 2026-04-09");
@@ -93,7 +93,7 @@ public class StandupPromptTests
 	[Fact]
 	public void BuildUserMessage_IncludesOpenerLine_WhenOpenerProvided()
 	{
-		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", "Crushed it.");
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", "Crushed it.", "Test goal");
 
 		message.ShouldContain("Open the first answer with exactly: \"Crushed it.\"");
 	}
@@ -101,9 +101,26 @@ public class StandupPromptTests
 	[Fact]
 	public void BuildUserMessage_OmitsOpenerLine_WhenOpenerNull()
 	{
-		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", null);
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", null, "Test goal");
 
 		message.ShouldNotContain("Open the first answer");
+	}
+
+	[Fact]
+	public void BuildUserMessage_InjectsWeeklyGoalDirective_WhenGoalProvided()
+	{
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", null, "Data Products support");
+
+		message.ShouldContain("tie today's One Thing to this exact weekly goal: \"Data Products support\"");
+	}
+
+	[Fact]
+	public void BuildUserMessage_InjectsNoGoalDirective_WhenGoalNull()
+	{
+		var message = StandupPrompts.BuildUserMessage("2026-04-07", "2026-04-06", "{}", null, null);
+
+		message.ShouldContain("no weekly goal this week");
+		message.ShouldNotContain("null");
 	}
 
 	[Fact]


### PR DESCRIPTION
## What

Reworks AI daily-standup generation (`POST /api/standup/generate`) so the endpoint precomputes a compact, structured context in C# and the prompt only handles tone/wording — instead of dumping full entities and asking the model to do date matching, ordering, goal lookup, and opener variety itself.

- **Structured payload** — `StandupContext` (weekly goal, yesterday's One Thing + status, yesterday's others, today's One Thing + also-on-deck, sync meetings, PTO) built in `StandupContextBuilder`.
- **Goal anchoring fix** — the real BigThing title is passed as data and injected as an explicit directive; few-shot examples use placeholders, so the model can no longer leak an example goal (the reported "Data Products support" bug).
- **Opener chosen in C#** — picked from the status bucket, excluding yesterday's saved opener, and injected as "Open the first answer with exactly: …" (the old "never repeat" instruction was unenforceable statelessly).
- **Forecast trimming** — only `syncMeetings`/`upcomingPTO` are parsed server-side (tolerant of missing/extra/malformed JSON).
- **Execution settings** — `Temperature = 0.35`.
- **Prompt dedup** — mid-week (3Q) and Friday (4Q) prompts composed from shared blocks.

## Fix on top (small-model robustness)

Manual testing surfaced that gpt-4o-mini would drop the `###` question headings when yesterday had no tracked One Thing — collapsing the response into one block with no per-answer copy — and echo a literal `**null**` weekly goal. Fixed by:

- An absolute output-format contract (always emit every heading, never merge answers, never print raw field values).
- Reframing null cases as answers *under* the heading rather than heading replacements.
- Omitting null members from the context JSON so the model never sees a `null` to echo.

## Testing

- Full API suite green (134 passing): new `StandupContextBuilderTests`, expanded endpoint/prompt tests, `FakeChatCompletionService` now captures execution settings.
- Live diagnostic runs against the gpt-4o-mini deployment across rich / sparse / null-goal data: **3 headings and no null/status leaks in every run.**
- `dotnet format` clean.

## Notes

- Monday / `commandType=weekly` remain on the legacy raw-items path (Monday prompt is still a TODO) — out of scope here.
- Frontend contract unchanged (`{ markdown }`); no web changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)