### PR TITLE
feat(web): focus first slash command item on menu open

### DIFF
--- a/web/src/components/SlashCommandMenu.spec.ts
+++ b/web/src/components/SlashCommandMenu.spec.ts
@@ -72,6 +72,18 @@ describe('SlashCommandMenu', () => {
     wrapper.unmount()
   })
 
+  it('SlashCommandMenu_FocusesFirstItem_WhenOpened', async () => {
+    const wrapper = mountComponent()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }))
+    await nextTick()
+    await nextTick()
+
+    expect(document.activeElement).toBe(wrapper.find('[data-testid="cmd-standup"]').element)
+
+    wrapper.unmount()
+  })
+
   it('SlashCommandMenu_EmitsCommand_WhenStandupClicked', async () => {
     const wrapper = mountComponent()
 

--- a/web/src/components/SlashCommandMenu.vue
+++ b/web/src/components/SlashCommandMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import type { CommandType } from '@/types'
 import { getRecentWeekStarts, formatWeekRange } from '@/utils/week'
 
@@ -11,6 +11,13 @@ const emit = defineEmits<{
 const isOpen = ref(false)
 const archiveOpen = ref(false)
 const panelRef = ref<HTMLDivElement | null>(null)
+const firstCommandRef = ref<HTMLButtonElement | null>(null)
+
+watch(isOpen, async (open) => {
+  if (!open) return
+  await nextTick()
+  firstCommandRef.value?.focus()
+})
 
 const recentWeeks = getRecentWeekStarts(5)
 
@@ -88,6 +95,7 @@ onUnmounted(() => {
 
         <div class="space-y-2">
           <button
+            ref="firstCommandRef"
             data-testid="cmd-standup"
             class="w-full text-left px-2 py-1 hover:bg-secondary/50 transition-colors"
             @click="handleCommandClick('standup')"

--- a/web/src/components/SlashCommandMenu.vue
+++ b/web/src/components/SlashCommandMenu.vue
@@ -16,6 +16,7 @@ const firstCommandRef = ref<HTMLButtonElement | null>(null)
 watch(isOpen, async (open) => {
   if (!open) return
   await nextTick()
+  if (!isOpen.value) return
   firstCommandRef.value?.focus()
 })
 


### PR DESCRIPTION
## Summary
- Focus the `/standup` item automatically when the slash command menu opens, so keyboard users can `Tab` between commands and press `Enter` to run one instead of reaching for the mouse
- Native `<button>` elements already support Tab-to-navigate and Enter-to-activate, so no additional key handling was needed beyond the initial focus

## Test plan
- [x] `npm run test` — full Vitest suite passes (235 tests), including new `SlashCommandMenu_FocusesFirstItem_WhenOpened`
- [x] `npm run lint` — clean
- [x] Manually verified in a running dev server: pressing `/` opens the menu and moves focus to the `/standup` button