### PR TITLE
refactor(api): extract ComputeWeekOf into shared WeekOfHelper

### DIFF
--- a/api/src/Endpoints/WorkItemEndpoints.cs
+++ b/api/src/Endpoints/WorkItemEndpoints.cs
@@ -1,3 +1,4 @@
+using DailyWork.Api;
 using DailyWork.Api.Data;
 using DailyWork.Api.Dtos;
 using DailyWork.Api.Entities;
@@ -35,7 +36,7 @@ internal static class WorkItemEndpoints
 				: WorkItemCategory.SmallThing;
 
 			var date = dto.Date ?? dateTime.UtcToday;
-			var weekOf = ComputeWeekOf(date);
+			var weekOf = WeekOfHelper.FromDate(date);
 
 			var sortOrder = 0;
 			if (category == WorkItemCategory.SmallThing)
@@ -166,7 +167,7 @@ internal static class WorkItemEndpoints
 			}
 
 			item.Date = dto.Date;
-			item.WeekOf = ComputeWeekOf(dto.Date);
+			item.WeekOf = WeekOfHelper.FromDate(dto.Date);
 			item.TimesMoved += 1;
 			await db.SaveChangesAsync();
 			return Results.Ok(item);
@@ -182,11 +183,5 @@ internal static class WorkItemEndpoints
 		});
 
 		return group;
-	}
-
-	private static string ComputeWeekOf(DateOnly date)
-	{
-		int daysToMonday = ((int)date.DayOfWeek - 1 + 7) % 7;
-		return date.AddDays(-daysToMonday).ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
 	}
 }

--- a/api/src/WeekOfHelper.cs
+++ b/api/src/WeekOfHelper.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+
+namespace DailyWork.Api;
+
+internal static class WeekOfHelper
+{
+	public static string FromDate(DateOnly date)
+	{
+		int daysToMonday = ((int)date.DayOfWeek - 1 + 7) % 7;
+		return date.AddDays(-daysToMonday).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+	}
+
+	public static bool IsValid(string weekOf)
+	{
+		return DateOnly.TryParseExact(weekOf, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)
+			&& date.DayOfWeek == DayOfWeek.Monday;
+	}
+}


### PR DESCRIPTION
## Summary
- Moves the Monday-of-week computation out of `WorkItemEndpoints` into a new `WeekOfHelper` static class
- Adds `WeekOfHelper.IsValid(string)`, a validity check (parses `yyyy-MM-dd` and confirms it's a Monday) needed by an upcoming feature — not yet used here
- Pure refactor, no behavior change to `WorkItemEndpoints`

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet format api/src --verify-no-changes` is clean
- [x] Full API test suite passes (141/141)